### PR TITLE
バス経路の停留所順序をshape_dist_traveledで決定するよう修正

### DIFF
--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -1564,11 +1564,22 @@ async fn integrate_gtfs_routes_to_lines(
 ///
 /// # Ordering Strategy
 ///
-/// ## 1. Main trip sequence
-/// - Select the trip with most stops as "main trip" (prefer direction_id=0)
+/// ## 1. shape_dist_traveled-based ordering (preferred)
+/// When `gtfs_stop_times.shape_dist_traveled` is populated for at least 80% of a
+/// route's stop_times, stops are ordered by that accumulated distance. The
+/// per-stop value is taken from a `direction_id=0` observation when available,
+/// otherwise from any direction. This avoids the unstable interpolation that the
+/// fallback strategy can produce for multi-variant routes (e.g. 池86).
+///
+/// ## 2. Main trip + variant interpolation (fallback)
+/// For routes where `shape_dist_traveled` coverage is below the 80% threshold:
+///
+/// ### 2a. Main trip sequence
+/// - Select a representative "main trip" per route (prefer direction_id=0, then
+///   most unique stops, then longest shape distance, then trip_id for stability)
 /// - Use stop_sequence from main trip directly
 ///
-/// ## 2. Variant stop estimation
+/// ### 2b. Variant stop estimation
 /// For stops only on variant trips:
 /// - Use LAG/LEAD to find neighboring stops on the variant trip
 /// - Look up neighbors' positions on the main trip

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -1579,13 +1579,63 @@ async fn build_stop_route_mapping(
     conn: &mut PgConnection,
 ) -> Result<HashMap<String, Vec<(String, i32)>>, Box<dyn std::error::Error>> {
     // Strategy:
-    // 1. Find the "main" trip for each route (most stops, prefer direction_id=0)
-    // 2. Use stop_sequence from main trip for stops on it
-    // 3. For variant-only stops, use LAG/LEAD to find neighbors, then look up their
-    //    main trip positions to estimate where the variant stop should go
+    // 1. If a route has reliable shape_dist_traveled coverage (>= 80% of stop_times),
+    //    order its stops by shape distance directly (preferring direction_id=0). This
+    //    is robust against multi-variant routes like 池86 where the main-trip + variant
+    //    interpolation produces unstable ordering.
+    // 2. Otherwise fall back to: pick a representative "main" trip and place variant-only
+    //    stops by interpolating from their LAG/LEAD neighbors on the main trip.
     let rows: Vec<(String, String, i32)> = sqlx::query_as(
-        r#"WITH RECURSIVE main_trips AS (
-               -- Find the trip with the most stops for each route (prefer direction_id=0)
+        r#"WITH RECURSIVE route_coverage AS (
+               -- Per-route coverage of shape_dist_traveled in stop_times
+               SELECT
+                   gt.route_id,
+                   COUNT(*) FILTER (WHERE gst.shape_dist_traveled IS NOT NULL)::FLOAT
+                       / NULLIF(COUNT(*), 0) AS coverage
+               FROM gtfs_trips gt
+               JOIN gtfs_stop_times gst ON gt.trip_id = gst.trip_id
+               GROUP BY gt.route_id
+           ),
+           shape_routes AS (
+               SELECT route_id FROM route_coverage WHERE coverage >= 0.8
+           ),
+           legacy_routes AS (
+               SELECT route_id FROM route_coverage
+               WHERE coverage IS NULL OR coverage < 0.8
+           ),
+           -- Shape-distance-based ordering: one row per (parent_stop, route),
+           -- preferring direction_id=0 observations, then the smallest distance.
+           shape_stop_dist AS (
+               SELECT DISTINCT ON (COALESCE(gs.parent_station, gs.stop_id), gt.route_id)
+                   COALESCE(gs.parent_station, gs.stop_id) AS parent_stop_id,
+                   gt.route_id,
+                   gst.shape_dist_traveled AS dist
+               FROM gtfs_trips gt
+               JOIN gtfs_stop_times gst ON gt.trip_id = gst.trip_id
+               JOIN gtfs_stops gs ON gst.stop_id = gs.stop_id
+               WHERE gt.route_id IN (SELECT route_id FROM shape_routes)
+                 AND gst.shape_dist_traveled IS NOT NULL
+               ORDER BY COALESCE(gs.parent_station, gs.stop_id),
+                        gt.route_id,
+                        CASE WHEN gt.direction_id = 0 THEN 0
+                             WHEN gt.direction_id IS NULL THEN 1
+                             ELSE 2 END,
+                        gst.shape_dist_traveled
+           ),
+           shape_numbered AS (
+               SELECT
+                   parent_stop_id,
+                   route_id,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY route_id
+                       ORDER BY dist, parent_stop_id
+                   )::INT AS stop_sequence
+               FROM shape_stop_dist
+           ),
+           main_trips AS (
+               -- Fallback: representative trip per legacy route.
+               -- Prefer direction_id=0, then most unique stops, then longest shape,
+               -- then trip_id for deterministic tiebreak.
                SELECT DISTINCT ON (gt.route_id)
                    gt.route_id,
                    gt.trip_id,
@@ -1593,10 +1643,14 @@ async fn build_stop_route_mapping(
                    COUNT(*) as stop_count
                FROM gtfs_trips gt
                JOIN gtfs_stop_times gst ON gt.trip_id = gst.trip_id
+               WHERE gt.route_id IN (SELECT route_id FROM legacy_routes)
                GROUP BY gt.route_id, gt.trip_id, gt.direction_id
                ORDER BY gt.route_id,
                         CASE WHEN gt.direction_id = 0 THEN 0 ELSE 1 END,
-                        COUNT(*) DESC
+                        COUNT(DISTINCT gst.stop_id) DESC,
+                        MAX(gst.shape_dist_traveled) DESC NULLS LAST,
+                        COUNT(*) DESC,
+                        gt.trip_id
            ),
            main_trip_stops AS (
                -- Get stops from main trips with their sequence
@@ -1631,7 +1685,8 @@ async fn build_stop_route_mapping(
                FROM gtfs_trips gt
                JOIN gtfs_stop_times gst ON gt.trip_id = gst.trip_id
                JOIN gtfs_stops gs ON gst.stop_id = gs.stop_id
-               WHERE NOT EXISTS (
+               WHERE gt.route_id IN (SELECT route_id FROM legacy_routes)
+                 AND NOT EXISTS (
                    SELECT 1 FROM main_trips mt WHERE mt.trip_id = gt.trip_id
                )
            ),
@@ -1852,8 +1907,9 @@ async fn build_stop_route_mapping(
                    ROW_NUMBER() OVER (PARTITION BY route_id ORDER BY seq, parent_stop_id)::INT as stop_sequence
                FROM unique_stops
            )
-           SELECT parent_stop_id, route_id, stop_sequence
-           FROM numbered
+           SELECT parent_stop_id, route_id, stop_sequence FROM shape_numbered
+           UNION ALL
+           SELECT parent_stop_id, route_id, stop_sequence FROM numbered
            ORDER BY route_id, stop_sequence"#,
     )
     .fetch_all(&mut *conn)


### PR DESCRIPTION
## 概要

池86のような多バリアントを持つバス系統で停留所が実経路と異なる順序で返る問題を、`gtfs_stop_times.shape_dist_traveled` を主軸に並べることで解消します。

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `build_stop_route_mapping()`（`stationapi/src/import.rs`）の SQL を書き換え、`shape_dist_traveled` のカバー率が 80% 以上の route はその累計距離で順序を決定（direction_id=0 優先）。
- カバー率不足の route は従来のメイントリップ + LAG/LEAD 補間にフォールバック。フォールバック側のメイントリップ選択基準も「ユニーク停留所数 → 最長 shape 距離 → trip_id」のタイブレークで決定論的にし、池86 のように同一停車数のトリップが多い系統でも結果が安定するようにしました。
- 戻り値の型と `integrate_gtfs_stops_to_stations()` のインターフェースは変更していないため、書き込み先 `stations.e_sort` を読む既存エンドポイント（`GetRoutes` / `GetRoutesMinimal` / `GetStationsByLineId` / `GetStationsByLineIdList`）すべてに自動で反映されます。
- 鉄道路線（`station_station_types` 経由・`sst.id` で並ぶ系）は本変更の影響を受けません。

反映時には `stations WHERE transport_type = 1` を削除して GTFS を再 import する必要があります。

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

`SQLX_OFFLINE=true cargo test` は 327 件パス（53 件 ignore はもとから DB 接続前提のもの）。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


---
_Generated by [Claude Code](https://claude.ai/code/session_013W9KJHaz8obo62ExuWrRu4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 停止シーケンス計算を強化しました。形状距離データが十分に得られるルートでは距離に基づく並びを優先し、データが限定的なルートでは従来の補完手法を用いることで、全ルートにわたり停止順序の精度と信頼性が向上します。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/StationAPI/pull/1511)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->