### PR TITLE
バスフルルートの誤認識を修正: canonical_shape選定で停留所数を最優先に変更

### DIFF
--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -1567,11 +1567,14 @@ async fn integrate_gtfs_routes_to_lines(
 /// ## 1. Main trip selection
 /// Pick one representative trip per route. The selection prefers:
 ///
-/// 1. Trips whose `shape_id` matches the route's canonical shape (the longest /
-///    most-stop-covering shape used by `direction_id=0` trips). This avoids
-///    picking a short-turn variant as the main trip even when it happens to
-///    have more rows in `gtfs_stop_times`.
-/// 2. `direction_id = 0`
+/// 1. Trips whose `shape_id` matches the route's canonical shape, where the
+///    canonical shape is the one covering the most unique stops (with longest
+///    `MAX(shape_dist_traveled)` and `direction_id=0` as tiebreakers). This
+///    avoids picking a short-turn variant when the full route only exists on
+///    trips with `direction_id` NULL — as is the case for 池86, whose full
+///    loop is recorded with `direction_id` empty while the only `direction_id=0`
+///    trip is a 13-stop short turn (新宿伊勢丹前→池袋駅東口).
+/// 2. `direction_id = 0` (then NULL, then 1)
 /// 3. Most unique stops
 /// 4. Longest `MAX(shape_dist_traveled)`
 /// 5. `trip_id` for a deterministic tiebreak
@@ -1591,7 +1594,13 @@ async fn build_stop_route_mapping(
     conn: &mut PgConnection,
 ) -> Result<HashMap<String, Vec<(String, i32)>>, Box<dyn std::error::Error>> {
     // Strategy:
-    // 1. Compute a canonical shape_id per route (longest direction_id=0 shape).
+    // 1. Compute a canonical shape_id per route: the shape covering the most unique
+    //    stops, with longest shape_dist_traveled and direction_id=0 as tiebreakers.
+    //    Length comes first because some routes (e.g. 池86) record their full route
+    //    only under direction_id NULL while a short-turn variant is the sole
+    //    direction_id=0 trip — preferring direction_id=0 first would pin the main
+    //    trip to that 13-stop short turn and push the full-route stops (渋谷駅東口,
+    //    宮下公園, etc.) into the variant-interpolation path.
     // 2. Pick a main trip per route, preferring trips on the canonical shape, then
     //    direction_id=0 / most stops / longest distance. Its stop_sequence is the
     //    canonical order. This avoids the earlier attempt's bug where
@@ -1605,8 +1614,11 @@ async fn build_stop_route_mapping(
                -- Pick one canonical shape_id per route. Used purely to bias main trip
                -- selection: a trip on the canonical shape is preferred over a trip
                -- with the same stop count on some short-turn / branching shape.
-               -- Prefer direction_id=0, then longest physical distance, then most
-               -- unique stops, then shape_id for a deterministic tiebreak.
+               -- Prefer the shape with the most unique stops, then longest physical
+               -- distance, then direction_id=0 (then NULL, then 1), then shape_id for
+               -- a deterministic tiebreak. Stop count comes before direction because
+               -- e.g. 池86 records its full loop only under direction_id NULL while
+               -- the sole direction_id=0 trip is a 13-stop short turn.
                SELECT DISTINCT ON (gt.route_id)
                    gt.route_id,
                    gt.shape_id
@@ -1615,9 +1627,11 @@ async fn build_stop_route_mapping(
                WHERE gt.shape_id IS NOT NULL
                GROUP BY gt.route_id, gt.shape_id, gt.direction_id
                ORDER BY gt.route_id,
-                        CASE WHEN gt.direction_id = 0 THEN 0 ELSE 1 END,
-                        MAX(gst.shape_dist_traveled) DESC NULLS LAST,
                         COUNT(DISTINCT gst.stop_id) DESC,
+                        MAX(gst.shape_dist_traveled) DESC NULLS LAST,
+                        CASE WHEN gt.direction_id = 0 THEN 0
+                             WHEN gt.direction_id IS NULL THEN 1
+                             ELSE 2 END,
                         gt.shape_id
            ),
            main_trips AS (


### PR DESCRIPTION
## 概要

`build_stop_route_mapping` の canonical_shape 選定で `direction_id=0` を最優先にしていたため、池86 のようにフルルートが `direction_id=NULL` のループのみで記録され、唯一の `direction_id=0` トリップが短ターン (新宿伊勢丹前→池袋駅東口) という路線で、短ターンシェイプが canonical に選ばれ main_trip もそれになっていた。結果、渋谷駅東口・宮下公園が variant 補間で main_trip に到達できず ELSE fallback で末尾 (`max_seq + 9999`) に追いやられ、表示が「新宿伊勢丹前 → … → 宮下公園」となっていた問題を修正する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `import.rs` の canonical_shape CTE `ORDER BY` を組み替え:
  - 修正前: `direction_id=0 優先 → MAX(shape_dist_traveled) → COUNT(stop_id)`
  - 修正後: `COUNT(DISTINCT stop_id) DESC → MAX(shape_dist_traveled) → direction_id (0 → NULL → 1) → shape_id`
- 池86 (route_id=152) では 48 停留所の shape `20007-3` が canonical に選ばれ、main_trip もこれになる。`池袋サンシャインシティ → 池袋駅東口 → … → 渋谷駅東口 → 宮下公園` の順に表示される。
- コードコメント / ドキュメントコメントも新ロジックに合わせて更新。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

`cargo test --bin stationapi import::` で 26 件のテストが全パス。ToeiBus GTFS の実データを取得し、route_id=152 のシェイプ別停留所数と direction_id の分布を確認した上で修正ロジックを設計。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->
