### PR TITLE
GitHub ActionsのusesをコミットSHAにピン留め (Closes #1499)

### DIFF
--- a/.github/workflows/deploy_ecs_production_stationapi.yml
+++ b/.github/workflows/deploy_ecs_production_stationapi.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
@@ -61,14 +61,14 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@6853cfae8c3a7d978fbf68b5a55453395541dfbb # v1
         with:
           task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}

--- a/.github/workflows/deploy_ecs_staging_stationapi.yml
+++ b/.github/workflows/deploy_ecs_staging_stationapi.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
@@ -61,14 +61,14 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@6853cfae8c3a7d978fbf68b5a55453395541dfbb # v1
         with:
           task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}


### PR DESCRIPTION
## 概要

ECSデプロイワークフロー（ステージング・本番）の GitHub Actions `uses:` 参照をバージョンタグ（`@v*`）から完全長のコミット SHA に変更し、確定的・再現可能なデプロイとサプライチェーン上のセキュリティを強化する。元タグは `# v4` のようにコメントで併記して Dependabot が追従できる形を維持。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

`.github/workflows/deploy_ecs_staging_stationapi.yml` および `.github/workflows/deploy_ecs_production_stationapi.yml` の以下 5 アクションをコミット SHA に固定（両ファイルとも同じ SHA を使用）。

- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
- `aws-actions/configure-aws-credentials@v4` → `aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4`
- `aws-actions/amazon-ecr-login@v2` → `aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2`
- `aws-actions/amazon-ecs-render-task-definition@v1` → `aws-actions/amazon-ecs-render-task-definition@6853cfae8c3a7d978fbf68b5a55453395541dfbb # v1`
- `aws-actions/amazon-ecs-deploy-task-definition@v2` → `aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2`

各 SHA は GitHub API（`repos/<owner>/<repo>/git/ref/tags/<tag>`）で当該タグが指す実コミットを参照して取得。`configure-aws-credentials@v4` は annotated tag のため、タグオブジェクトから実コミット SHA を解決した。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `cargo fmt --all -- --check` が通ること
- [ ] `cargo clippy -- -D warnings` が通ること
- [ ] `cargo test`（`SQLX_OFFLINE=true`）が通ること

省略: コード（`stationapi/**` ほか）の変更なし、ワークフローファイルのみの変更のため `cargo` チェックは対象外。

## 関連Issue

Closes #1499

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Chores**
  * デプロイワークフローのセキュリティと安定性を強化するため、本番環境およびステージング環境で使用するGitHub Actionsを特定のバージョンに固定しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/StationAPI/pull/1522)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->