### PR TITLE
master<-dev

### DIFF
--- a/.github/workflows/deploy_ecs_production_stationapi.yml
+++ b/.github/workflows/deploy_ecs_production_stationapi.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
@@ -61,14 +61,14 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@6853cfae8c3a7d978fbf68b5a55453395541dfbb # v1
         with:
           task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}

--- a/.github/workflows/deploy_ecs_production_stationapi.yml
+++ b/.github/workflows/deploy_ecs_production_stationapi.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".sqlx/**"
       - "data/**"
+      - "docker/**"
       - "scripts/**"
       - "stationapi/**"
       - "Cargo.lock"

--- a/.github/workflows/deploy_ecs_staging_stationapi.yml
+++ b/.github/workflows/deploy_ecs_staging_stationapi.yml
@@ -30,12 +30,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -43,7 +43,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: Build, tag, and push image to Amazon ECR
         id: build-image
@@ -61,14 +61,14 @@ jobs:
 
       - name: Fill in the new image ID in the Amazon ECS task definition
         id: task-def
-        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        uses: aws-actions/amazon-ecs-render-task-definition@6853cfae8c3a7d978fbf68b5a55453395541dfbb # v1
         with:
           task-definition: task-definition.json
           container-name: ${{ env.CONTAINER_NAME }}
           image: ${{ steps.build-image.outputs.image }}
 
       - name: Deploy Amazon ECS task definition
-        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        uses: aws-actions/amazon-ecs-deploy-task-definition@a310a830f5c14e583e35d84e4e1ec7dd177c3c9c # v2
         with:
           task-definition: ${{ steps.task-def.outputs.task-definition }}
           service: ${{ env.ECS_SERVICE }}

--- a/.github/workflows/deploy_ecs_staging_stationapi.yml
+++ b/.github/workflows/deploy_ecs_staging_stationapi.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - ".sqlx/**"
       - "data/**"
+      - "docker/**"
       - "scripts/**"
       - "stationapi/**"
       - "Cargo.lock"

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -2995,4 +2995,520 @@ mod tests {
         assert_eq!(parse_gtfs_time("01:02:03"), Some("01:02:03".to_string()));
         assert_eq!(parse_gtfs_time("00:00:01"), Some("00:00:01".to_string()));
     }
+
+    // ============================================================================
+    // build_stop_route_mapping regression tests
+    //
+    // 実 PostgreSQL を前提とした回帰テスト。`build_stop_route_mapping()` が
+    // 読み取る 3 テーブル (gtfs_trips / gtfs_stop_times / gtfs_stops) を
+    // 隔離スキーマに最小構成で再現し、出力マッピングを assert する。
+    //
+    // 既定では `#[ignore]` で除外され、`integration-tests` feature を付けたとき
+    // のみ実行される。ローカルでの実行例:
+    //
+    //     export TEST_DATABASE_URL=postgres://test:test@localhost/stationapi_test
+    //     cargo test -p stationapi --features integration-tests \
+    //         build_stop_route_mapping
+    //
+    // テストは並列実行可能。各テストが per-process カウンタとナノ秒タイムスタンプ
+    // から生成したユニークなスキーマ名を使うので、複数スレッドで衝突しない。
+    // パニックでテストが中断するとスキーマがクリーンアップされず残るが、
+    // スキーマ名がユニークなので後続実行には影響しない (テスト DB を作り直す
+    // 際にまとめて消えるので運用上問題ない)。
+    // ============================================================================
+
+    mod stop_route_mapping_fixtures {
+        use sqlx::{Connection, Executor, PgConnection};
+        use std::env;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        static SCHEMA_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+        pub fn unique_schema_name() -> String {
+            let id = SCHEMA_COUNTER.fetch_add(1, Ordering::SeqCst);
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            format!("brsm_test_{nanos}_{id}")
+        }
+
+        pub async fn open_conn() -> PgConnection {
+            let database_url = env::var("TEST_DATABASE_URL")
+                .unwrap_or_else(|_| "postgres://test:test@localhost/stationapi_test".to_string());
+            PgConnection::connect(&database_url)
+                .await
+                .expect("Failed to connect to test database. Set TEST_DATABASE_URL.")
+        }
+
+        /// 隔離スキーマと最小 GTFS テーブルを作成し、search_path を切り替える。
+        /// 戻り値のスキーマ名は呼び出し側が `drop_schema` で破棄すること。
+        pub async fn setup_schema(conn: &mut PgConnection) -> String {
+            let schema = unique_schema_name();
+            conn.execute(format!("CREATE SCHEMA \"{schema}\"").as_str())
+                .await
+                .expect("create schema");
+            conn.execute(format!("SET search_path TO \"{schema}\"").as_str())
+                .await
+                .expect("set search_path");
+            conn.execute(
+                r#"
+                CREATE TABLE gtfs_stops (
+                    stop_id VARCHAR(255) PRIMARY KEY,
+                    stop_name TEXT NOT NULL DEFAULT '',
+                    stop_lat DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    stop_lon DOUBLE PRECISION NOT NULL DEFAULT 0,
+                    parent_station VARCHAR(255)
+                );
+                CREATE TABLE gtfs_trips (
+                    trip_id VARCHAR(255) PRIMARY KEY,
+                    route_id VARCHAR(255) NOT NULL,
+                    service_id VARCHAR(255) NOT NULL DEFAULT 'svc',
+                    direction_id INTEGER,
+                    shape_id VARCHAR(255)
+                );
+                CREATE TABLE gtfs_stop_times (
+                    id SERIAL PRIMARY KEY,
+                    trip_id VARCHAR(255) NOT NULL REFERENCES gtfs_trips(trip_id),
+                    stop_id VARCHAR(255) NOT NULL REFERENCES gtfs_stops(stop_id),
+                    stop_sequence INTEGER NOT NULL,
+                    shape_dist_traveled DOUBLE PRECISION
+                );
+                "#,
+            )
+            .await
+            .expect("create gtfs tables");
+            schema
+        }
+
+        pub async fn drop_schema(conn: &mut PgConnection, schema: &str) {
+            let _ = conn.execute("RESET search_path").await;
+            let _ = conn
+                .execute(format!("DROP SCHEMA \"{schema}\" CASCADE").as_str())
+                .await;
+        }
+
+        pub async fn insert_stop(conn: &mut PgConnection, stop_id: &str) {
+            sqlx::query("INSERT INTO gtfs_stops (stop_id, parent_station) VALUES ($1, NULL)")
+                .bind(stop_id)
+                .execute(&mut *conn)
+                .await
+                .expect("insert stop");
+        }
+
+        pub async fn insert_pole(conn: &mut PgConnection, stop_id: &str, parent_station: &str) {
+            sqlx::query("INSERT INTO gtfs_stops (stop_id, parent_station) VALUES ($1, $2)")
+                .bind(stop_id)
+                .bind(parent_station)
+                .execute(&mut *conn)
+                .await
+                .expect("insert pole");
+        }
+
+        /// trip と対応する stop_times を一括投入する。`stops` の要素は
+        /// `(stop_id, shape_dist_traveled)` で、`stop_sequence` は要素順に
+        /// 1 から自動採番される。
+        pub async fn insert_trip_with_stops(
+            conn: &mut PgConnection,
+            trip_id: &str,
+            route_id: &str,
+            direction_id: Option<i32>,
+            shape_id: Option<&str>,
+            stops: &[(&str, Option<f64>)],
+        ) {
+            sqlx::query(
+                "INSERT INTO gtfs_trips (trip_id, route_id, direction_id, shape_id) \
+                 VALUES ($1, $2, $3, $4)",
+            )
+            .bind(trip_id)
+            .bind(route_id)
+            .bind(direction_id)
+            .bind(shape_id)
+            .execute(&mut *conn)
+            .await
+            .expect("insert trip");
+            for (idx, (stop_id, dist)) in stops.iter().enumerate() {
+                sqlx::query(
+                    "INSERT INTO gtfs_stop_times \
+                       (trip_id, stop_id, stop_sequence, shape_dist_traveled) \
+                     VALUES ($1, $2, $3, $4)",
+                )
+                .bind(trip_id)
+                .bind(*stop_id)
+                .bind((idx as i32) + 1)
+                .bind(*dist)
+                .execute(&mut *conn)
+                .await
+                .expect("insert stop_time");
+            }
+        }
+    }
+
+    /// マッピングから特定の route_id について `(parent_stop_id, seq)` を
+    /// `seq` 昇順で抜き出すヘルパ。
+    fn collect_route(
+        mapping: &HashMap<String, Vec<(String, i32)>>,
+        route_id: &str,
+    ) -> Vec<(String, i32)> {
+        let mut out: Vec<(String, i32)> = mapping
+            .iter()
+            .filter_map(|(stop, entries)| {
+                entries
+                    .iter()
+                    .find(|(r, _)| r == route_id)
+                    .map(|(_, seq)| (stop.clone(), *seq))
+            })
+            .collect();
+        out.sort_by_key(|(_, seq)| *seq);
+        out
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "integration-tests"), ignore)]
+    async fn test_build_stop_route_mapping_ike86_canonical_shape() {
+        // 池86 風シナリオ: 同一 route_id に複数 shape_id があり、最多停留所の
+        // shape は direction_id=NULL、唯一の direction_id=0 trip は短縮便。
+        // canonical_shape は stops 数を最優先するので shape_full が選ばれ、
+        // main_trip も trip_full になるべき。
+        // (PR #1515 で導入された挙動の lock-in テスト。)
+        let mut conn = stop_route_mapping_fixtures::open_conn().await;
+        let schema = stop_route_mapping_fixtures::setup_schema(&mut conn).await;
+        for s in ["S01", "S02", "S03", "S04", "S05"] {
+            stop_route_mapping_fixtures::insert_stop(&mut conn, s).await;
+        }
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_full",
+            "IKE86",
+            None,
+            Some("shape_full"),
+            &[
+                ("S01", Some(0.0)),
+                ("S02", Some(100.0)),
+                ("S03", Some(200.0)),
+                ("S04", Some(300.0)),
+                ("S05", Some(400.0)),
+            ],
+        )
+        .await;
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_short",
+            "IKE86",
+            Some(0),
+            Some("shape_short"),
+            &[("S01", Some(0.0)), ("S02", Some(50.0))],
+        )
+        .await;
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_inbound",
+            "IKE86",
+            Some(1),
+            Some("shape_in"),
+            &[
+                ("S05", Some(0.0)),
+                ("S04", Some(100.0)),
+                ("S03", Some(200.0)),
+                ("S02", Some(300.0)),
+                ("S01", Some(400.0)),
+            ],
+        )
+        .await;
+
+        let mapping = build_stop_route_mapping(&mut conn).await.unwrap();
+        let actual = collect_route(&mapping, "IKE86");
+        stop_route_mapping_fixtures::drop_schema(&mut conn, &schema).await;
+
+        assert_eq!(
+            actual,
+            vec![
+                ("S01".to_string(), 1),
+                ("S02".to_string(), 2),
+                ("S03".to_string(), 3),
+                ("S04".to_string(), 4),
+                ("S05".to_string(), 5),
+            ],
+            "canonical_shape は stop 数最多の shape_full を選び、\
+             main_trip もそこから取られるべき"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "integration-tests"), ignore)]
+    async fn test_build_stop_route_mapping_canonical_shape_direction_tiebreak() {
+        // stops 数と shape_dist_traveled が並ぶ場合、canonical_shape の
+        // タイブレークで direction_id=0 が NULL/1 に勝つことを確認する。
+        // shape_a は逆順、shape_b は順方向。canonical=shape_b になれば
+        // 結果は順方向になる。
+        let mut conn = stop_route_mapping_fixtures::open_conn().await;
+        let schema = stop_route_mapping_fixtures::setup_schema(&mut conn).await;
+        for s in ["S01", "S02", "S03"] {
+            stop_route_mapping_fixtures::insert_stop(&mut conn, s).await;
+        }
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_a",
+            "R1",
+            None,
+            Some("shape_a"),
+            &[
+                ("S03", Some(0.0)),
+                ("S02", Some(100.0)),
+                ("S01", Some(200.0)),
+            ],
+        )
+        .await;
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_b",
+            "R1",
+            Some(0),
+            Some("shape_b"),
+            &[
+                ("S01", Some(0.0)),
+                ("S02", Some(100.0)),
+                ("S03", Some(200.0)),
+            ],
+        )
+        .await;
+
+        let mapping = build_stop_route_mapping(&mut conn).await.unwrap();
+        let actual = collect_route(&mapping, "R1");
+        stop_route_mapping_fixtures::drop_schema(&mut conn, &schema).await;
+
+        assert_eq!(
+            actual,
+            vec![
+                ("S01".to_string(), 1),
+                ("S02".to_string(), 2),
+                ("S03".to_string(), 3),
+            ],
+            "direction_id=0 の shape_b が canonical に選ばれ、順方向順序になるべき"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "integration-tests"), ignore)]
+    async fn test_build_stop_route_mapping_main_trip_prefers_direction_zero() {
+        // canonical_shape を共有する 2 つの trip があるとき、main_trip は
+        // direction_id=0 のものが選ばれる。逆方向の trip_dir1 と順方向の
+        // trip_dir0 を同じ shape_main に乗せ、結果が順方向になることを確認。
+        let mut conn = stop_route_mapping_fixtures::open_conn().await;
+        let schema = stop_route_mapping_fixtures::setup_schema(&mut conn).await;
+        for s in ["S01", "S02", "S03", "S04"] {
+            stop_route_mapping_fixtures::insert_stop(&mut conn, s).await;
+        }
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_dir1",
+            "R2",
+            Some(1),
+            Some("shape_main"),
+            &[
+                ("S04", Some(0.0)),
+                ("S03", Some(100.0)),
+                ("S02", Some(200.0)),
+                ("S01", Some(300.0)),
+            ],
+        )
+        .await;
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_dir0",
+            "R2",
+            Some(0),
+            Some("shape_main"),
+            &[
+                ("S01", Some(0.0)),
+                ("S02", Some(100.0)),
+                ("S03", Some(200.0)),
+                ("S04", Some(300.0)),
+            ],
+        )
+        .await;
+
+        let mapping = build_stop_route_mapping(&mut conn).await.unwrap();
+        let actual = collect_route(&mapping, "R2");
+        stop_route_mapping_fixtures::drop_schema(&mut conn, &schema).await;
+
+        assert_eq!(
+            actual,
+            vec![
+                ("S01".to_string(), 1),
+                ("S02".to_string(), 2),
+                ("S03".to_string(), 3),
+                ("S04".to_string(), 4),
+            ],
+            "main_trip は direction_id=0 の trip_dir0 を選び、結果は順方向になるべき"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "integration-tests"), ignore)]
+    async fn test_build_stop_route_mapping_variant_chain_recursive_interpolation() {
+        // メイン系統に乗らない停留所が連鎖する場合、再帰 CTE で両端を解決して
+        // 中央付近の位置に補間できることを確認する。
+        //
+        // main_trip: M1, M2, M3, M4, M5            (seq 1..5)
+        // variant : M1, V1, V2, V3, M5
+        //   - V1: prev=M1(main), next=V2(variant)  → direct prev: 1 + 0.5 = 1.5
+        //   - V2: prev=V1(variant), next=V3(variant) → 再帰両端: (1+5)/2 = 3.0
+        //   - V3: prev=V2(variant), next=M5(main)  → direct next: 5 - 0.5 = 4.5
+        //
+        // 番号付け後 (ORDER BY seq, parent_stop_id):
+        //   M1=1, V1=2, M2=3, M3=4 ("M3" < "V2" の辞書順タイブレーク),
+        //   V2=5, M4=6, V3=7, M5=8
+        let mut conn = stop_route_mapping_fixtures::open_conn().await;
+        let schema = stop_route_mapping_fixtures::setup_schema(&mut conn).await;
+        for s in ["M1", "M2", "M3", "M4", "M5", "V1", "V2", "V3"] {
+            stop_route_mapping_fixtures::insert_stop(&mut conn, s).await;
+        }
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_main",
+            "R3",
+            Some(0),
+            Some("shape_main"),
+            &[
+                ("M1", Some(0.0)),
+                ("M2", Some(100.0)),
+                ("M3", Some(200.0)),
+                ("M4", Some(300.0)),
+                ("M5", Some(400.0)),
+            ],
+        )
+        .await;
+        // shape_variant の max_dist は shape_main (400) より低くしておく。
+        // 両 shape は同じ 5 停留所 だが MAX(shape_dist_traveled) が高い方が
+        // canonical_shape のタイブレークで勝つため、ここで意図的に
+        // shape_main を canonical にする。
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_variant",
+            "R3",
+            Some(0),
+            Some("shape_variant"),
+            &[
+                ("M1", Some(0.0)),
+                ("V1", Some(50.0)),
+                ("V2", Some(150.0)),
+                ("V3", Some(250.0)),
+                ("M5", Some(350.0)),
+            ],
+        )
+        .await;
+
+        let mapping = build_stop_route_mapping(&mut conn).await.unwrap();
+        let actual = collect_route(&mapping, "R3");
+        stop_route_mapping_fixtures::drop_schema(&mut conn, &schema).await;
+
+        assert_eq!(
+            actual,
+            vec![
+                ("M1".to_string(), 1),
+                ("V1".to_string(), 2),
+                ("M2".to_string(), 3),
+                ("M3".to_string(), 4),
+                ("V2".to_string(), 5),
+                ("M4".to_string(), 6),
+                ("V3".to_string(), 7),
+                ("M5".to_string(), 8),
+            ],
+            "V2 は再帰 CTE で両端 (M1, M5) を解決し、中央付近に挿入されるべき"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "integration-tests"), ignore)]
+    async fn test_build_stop_route_mapping_null_shape_dist_traveled() {
+        // shape_dist_traveled が全行 NULL でも canonical/main の選択ロジックが
+        // フォールバックして動作することを確認する。stops 数で shape_long が
+        // canonical に選ばれ、その停留所順がそのまま結果になる。
+        let mut conn = stop_route_mapping_fixtures::open_conn().await;
+        let schema = stop_route_mapping_fixtures::setup_schema(&mut conn).await;
+        for s in ["S01", "S02", "S03", "S04"] {
+            stop_route_mapping_fixtures::insert_stop(&mut conn, s).await;
+        }
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_short",
+            "R4",
+            Some(0),
+            Some("shape_short"),
+            &[("S01", None), ("S02", None), ("S03", None)],
+        )
+        .await;
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_long",
+            "R4",
+            Some(0),
+            Some("shape_long"),
+            &[("S01", None), ("S02", None), ("S03", None), ("S04", None)],
+        )
+        .await;
+
+        let mapping = build_stop_route_mapping(&mut conn).await.unwrap();
+        let actual = collect_route(&mapping, "R4");
+        stop_route_mapping_fixtures::drop_schema(&mut conn, &schema).await;
+
+        assert_eq!(
+            actual,
+            vec![
+                ("S01".to_string(), 1),
+                ("S02".to_string(), 2),
+                ("S03".to_string(), 3),
+                ("S04".to_string(), 4),
+            ],
+            "shape_dist_traveled が NULL でも stops 数で shape_long が \
+             canonical に選ばれ、その順序が返るべき"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "integration-tests"), ignore)]
+    async fn test_build_stop_route_mapping_parent_station_grouping() {
+        // 同一物理停留所の複数ポール (parent_station 経由) は
+        // `COALESCE(parent_station, stop_id)` で集約され、結果のキーは
+        // 親停留所 ID になることを確認する。
+        // P1, P2 が物理停留所。各 trip は別ポールを使うが、結果上は P1, P2
+        // として 1 レコードずつになる。
+        let mut conn = stop_route_mapping_fixtures::open_conn().await;
+        let schema = stop_route_mapping_fixtures::setup_schema(&mut conn).await;
+        stop_route_mapping_fixtures::insert_stop(&mut conn, "P1").await;
+        stop_route_mapping_fixtures::insert_stop(&mut conn, "P2").await;
+        stop_route_mapping_fixtures::insert_pole(&mut conn, "P1_a", "P1").await;
+        stop_route_mapping_fixtures::insert_pole(&mut conn, "P1_b", "P1").await;
+        stop_route_mapping_fixtures::insert_pole(&mut conn, "P2_a", "P2").await;
+        stop_route_mapping_fixtures::insert_pole(&mut conn, "P2_b", "P2").await;
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_ab",
+            "R5",
+            Some(0),
+            Some("shape_ab"),
+            &[("P1_a", Some(0.0)), ("P2_a", Some(100.0))],
+        )
+        .await;
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_ba",
+            "R5",
+            Some(1),
+            Some("shape_ba"),
+            &[("P2_b", Some(0.0)), ("P1_b", Some(100.0))],
+        )
+        .await;
+
+        let mapping = build_stop_route_mapping(&mut conn).await.unwrap();
+        let actual = collect_route(&mapping, "R5");
+        stop_route_mapping_fixtures::drop_schema(&mut conn, &schema).await;
+
+        assert_eq!(
+            actual,
+            vec![("P1".to_string(), 1), ("P2".to_string(), 2)],
+            "結果は親停留所 ID (P1, P2) で集約され、ポール ID は混入しないべき"
+        );
+    }
 }

--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -1762,6 +1762,19 @@ async fn build_stop_route_mapping(
                         END,
                         vts.stop_sequence
            ),
+           -- Per-route upper bound for the prev/next recursion depth. The chain
+           -- can revisit each variant-only stop at most once (enforced by the
+           -- `visited` array), so the variant-only stop count plus a small
+           -- safety margin is a safe and tight cap. This replaces the previous
+           -- fixed limit of 10, which truncated chains on routes whose variant
+           -- detour spans 11+ stops before rejoining the main trip.
+           variant_chain_limit AS (
+               SELECT
+                   route_id,
+                   COUNT(*)::INT + 1 AS max_depth
+               FROM variant_only_with_neighbors
+               GROUP BY route_id
+           ),
            -- Recursive CTE to find the nearest main-trip stop by following prev chain
            prev_chain AS (
                -- Base case: start from each variant stop
@@ -1787,7 +1800,9 @@ async fn build_stop_route_mapping(
                JOIN variant_only_with_neighbors von2
                    ON pc.current_stop_id = von2.parent_stop_id
                    AND pc.route_id = von2.route_id
-               WHERE pc.depth < 10
+               JOIN variant_chain_limit vcl
+                   ON vcl.route_id = pc.route_id
+               WHERE pc.depth < vcl.max_depth
                    AND von2.prev_stop_id IS NOT NULL
                    AND NOT pc.current_stop_id::TEXT = ANY(pc.visited)
                    -- Stop if we already found a main-trip stop
@@ -1833,7 +1848,9 @@ async fn build_stop_route_mapping(
                JOIN variant_only_with_neighbors von2
                    ON nc.current_stop_id = von2.parent_stop_id
                    AND nc.route_id = von2.route_id
-               WHERE nc.depth < 10
+               JOIN variant_chain_limit vcl
+                   ON vcl.route_id = nc.route_id
+               WHERE nc.depth < vcl.max_depth
                    AND von2.next_stop_id IS NOT NULL
                    AND NOT nc.current_stop_id::TEXT = ANY(nc.visited)
                    AND NOT EXISTS (
@@ -3416,6 +3433,112 @@ mod tests {
                 ("M5".to_string(), 8),
             ],
             "V2 は再帰 CTE で両端 (M1, M5) を解決し、中央付近に挿入されるべき"
+        );
+    }
+
+    #[tokio::test]
+    #[cfg_attr(not(feature = "integration-tests"), ignore)]
+    async fn test_build_stop_route_mapping_long_variant_chain_dynamic_limit() {
+        // 12 連続の variant-only 停留所をはさむ系統で、再帰 CTE の深さ上限が
+        // 動的に拡張されることを確認する (issue #1513)。
+        //
+        // 旧実装は `depth < 10` で打ち切るため、V11/V12 のうち両端が variant の
+        // ものは prev_chain で M1 まで到達できず、`mtms.max_seq + 9999` の末尾
+        // フォールバックや「next のみ解決」ブランチに落ち、メイン系統の末尾
+        // 付近に押し出されてしまっていた。
+        //
+        // main_trip: M01..M15           (seq 1..15, shape_main, 15 unique stops)
+        // variant : M01, V01..V12, M15  (shape_variant, 14 unique stops)
+        //
+        // canonical_shape は stop 数で shape_main が勝ち、M01..M15 はそのまま
+        // main_trip_stops に並ぶ。V01 は prev=M01 で直接補間 (1.5)、V12 は
+        // next=M15 で直接補間 (14.5)。中央の V02..V11 は両側 variant なので
+        // prev_chain と next_chain の双方を踏破して M01/M15 を解決し、
+        // (1+15)/2 + (prev_depth - next_depth) * 0.01 で 7.91..8.09 に並ぶ。
+        let mut conn = stop_route_mapping_fixtures::open_conn().await;
+        let schema = stop_route_mapping_fixtures::setup_schema(&mut conn).await;
+
+        let main_stops: Vec<String> = (1..=15).map(|i| format!("M{:02}", i)).collect();
+        let variant_stops: Vec<String> = (1..=12).map(|i| format!("V{:02}", i)).collect();
+        for s in main_stops.iter().chain(variant_stops.iter()) {
+            stop_route_mapping_fixtures::insert_stop(&mut conn, s).await;
+        }
+
+        let main_trip_stops: Vec<(&str, Option<f64>)> = main_stops
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.as_str(), Some((i as f64) * 100.0)))
+            .collect();
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_main",
+            "R6",
+            Some(0),
+            Some("shape_main"),
+            &main_trip_stops,
+        )
+        .await;
+
+        // variant: M01 → V01..V12 → M15。distance は main 側より短くしておく
+        // (canonical の決定は stop 数優先なので shape_main が勝つ)。
+        let mut variant_trip: Vec<(&str, Option<f64>)> = Vec::with_capacity(14);
+        variant_trip.push(("M01", Some(0.0)));
+        for (i, v) in variant_stops.iter().enumerate() {
+            variant_trip.push((v.as_str(), Some(((i as f64) + 1.0) * 50.0)));
+        }
+        variant_trip.push(("M15", Some(((variant_stops.len() as f64) + 1.0) * 50.0)));
+        stop_route_mapping_fixtures::insert_trip_with_stops(
+            &mut conn,
+            "trip_variant",
+            "R6",
+            Some(0),
+            Some("shape_variant"),
+            &variant_trip,
+        )
+        .await;
+
+        let mapping = build_stop_route_mapping(&mut conn).await.unwrap();
+        let actual = collect_route(&mapping, "R6");
+        stop_route_mapping_fixtures::drop_schema(&mut conn, &schema).await;
+
+        let expected: Vec<(String, i32)> = vec![
+            ("M01", 1),
+            ("V01", 2),
+            ("M02", 3),
+            ("M03", 4),
+            ("M04", 5),
+            ("M05", 6),
+            ("M06", 7),
+            ("M07", 8),
+            ("V02", 9),
+            ("V03", 10),
+            ("V04", 11),
+            ("V05", 12),
+            ("V06", 13),
+            ("M08", 14),
+            ("V07", 15),
+            ("V08", 16),
+            ("V09", 17),
+            ("V10", 18),
+            ("V11", 19),
+            ("M09", 20),
+            ("M10", 21),
+            ("M11", 22),
+            ("M12", 23),
+            ("M13", 24),
+            ("M14", 25),
+            ("V12", 26),
+            ("M15", 27),
+        ]
+        .into_iter()
+        .map(|(s, n)| (s.to_string(), n))
+        .collect();
+
+        assert_eq!(
+            actual, expected,
+            "12 段の variant チェーンでも V02..V11 が両端 (M01, M15) を再帰解決し、\
+             メイン系統の中央 (M07..M09 付近) に補間されるべき。旧 `depth < 10` では \
+             V11 が next のみ解決されて M14 付近 (~14.8) に流される回帰が発生する"
         );
     }
 


### PR DESCRIPTION
## 概要

dev ブランチに溜まった変更を master へ反映するリリース PR。`variant` 補間の再帰深さ上限の動的算出、`build_stop_route_mapping` の SQL 回帰テスト基盤、ECS デプロイワークフローの整備を含む。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- バグ修正
  - `variant` 補間の再帰深さ上限を route ごとの停留所数から動的に算出 (#1520)
- テスト基盤
  - `build_stop_route_mapping` の SQL 回帰テスト基盤を整備 (#1519)
- CI/CD
  - ECS デプロイワークフローの `paths` フィルタに `docker/**` を追加 (#1521)
  - GitHub Actions の `uses` をコミット SHA にピン留め (#1522)

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

#1499 #1513 #1514

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->
