### PR TITLE
バス種別名の「行」接尾辞を削除

### DIFF
--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -2463,17 +2463,17 @@ async fn integrate_gtfs_trip_variations_to_types(
         let is_bidirectional = directions.len() > 1;
 
         // Naming rule:
-        // - 双方向ペア (同じ停留所集合, direction 0/1) → "<A> ⇔ <B>" (両端駅) ※「行」は付けない
-        // - 循環トリップ (始発 parent == 終点 parent) → "<headsign>行（<経由地>経由・循環）"
-        //   (経由地が取れなければ "<headsign>行 (循環)" にフォールバック)
-        // - それ以外で始発名と headsign が異なる → "<first_stop> → <headsign>行"
-        // - 始発名と headsign が同じ / どちらか欠落 → headsign があれば "<headsign>行"、
-        //   無ければ "<first_stop>" (始発名は行き先ではないので「行」は付けない)
+        // - 双方向ペア (同じ停留所集合, direction 0/1) → "<A> ⇔ <B>" (両端駅)
+        // - 循環トリップ (始発 parent == 終点 parent) → "<headsign>（<経由地>経由・循環）"
+        //   (経由地が取れなければ "<headsign> (循環)" にフォールバック)
+        // - それ以外で始発名と headsign が異なる → "<first_stop> → <headsign>"
+        // - 始発名と headsign が同じ / どちらか欠落 → headsign があれば "<headsign>"、
+        //   無ければ "<first_stop>"
         // - すべて欠落 → "shape <shape_id>" でフォールバック
         let loop_name = |label: &str| -> String {
             match via_for_rep.get(&rep_idx) {
-                Some(via) => format!("{}行（{}経由・循環）", label, via),
-                None => format!("{}行 (循環)", label),
+                Some(via) => format!("{}（{}経由・循環）", label, via),
+                None => format!("{} (循環)", label),
             }
         };
         // Roman counterpart: "<label> via <via> (Loop)" / "<label> (Loop)". When the via
@@ -2507,9 +2507,9 @@ async fn integrate_gtfs_trip_variations_to_types(
                 (true, _, Some(h)) => loop_name(h),
                 (true, Some(first), None) => loop_name(first),
                 (false, Some(first), Some(h)) if first != h => {
-                    format!("{} → {}行", first, h)
+                    format!("{} → {}", first, h)
                 }
-                (_, _, Some(h)) => format!("{}行", h),
+                (_, _, Some(h)) => h.to_string(),
                 (_, Some(first), None) => first.to_string(),
                 _ => format!("shape {}", v.shape_id),
             }


### PR DESCRIPTION
## 概要

バス variant の `type_name` 生成ロジックから、行き先に付く「行」接尾辞を除去します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

`stationapi/src/import.rs` のバス variant 命名ロジック (`build_bus_variants` 周辺、L2466-L2515) を更新し、以下のとおり「行」接尾辞を削除しました。

| ケース | 変更前 | 変更後 |
| ---- | ---- | ---- |
| 循環便（経由地あり） | `{headsign}行（{via}経由・循環）` | `{headsign}（{via}経由・循環）` |
| 循環便（経由地なし） | `{headsign}行 (循環)` | `{headsign} (循環)` |
| 始発 ≠ headsign | `{first} → {headsign}行` | `{first} → {headsign}` |
| headsign のみ | `{headsign}行` | `{headsign}` |

- 双方向ペア (`A ⇔ B`) は元々「行」を付けていなかったため変更なし。
- ローマ字側 (`loop_name_r` ほか) も元々「行」相当の語を含まないため変更なし。
- 命名ルールを説明するコメントブロックも実装に合わせて更新。

## テスト

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * GTFS バス路線の日本語表記形式を更新しました。往路・復路を含む路線名表記、および循環路線・非循環路線の名称から末尾の「行」表記を削除し、より簡潔な形式に統一されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/StationAPI/pull/1524)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->