### PR TITLE
CSVインポートとGTFSインポートを並行実行

### DIFF
--- a/stationapi/src/import.rs
+++ b/stationapi/src/import.rs
@@ -38,13 +38,13 @@ type StopTimeBatchRow = (
     Option<i32>,
 );
 
-/// Import CSV data from the data directory
-pub async fn import_csv() -> Result<(), Box<dyn std::error::Error>> {
+/// Create required extensions and tables before running data imports.
+/// Must be called before `import_csv` and `import_gtfs` can run in parallel.
+pub async fn create_schema() -> Result<(), Box<dyn std::error::Error>> {
     let db_url = fetch_database_url();
     let mut conn = PgConnection::connect(&db_url).await?;
     let data_path = Path::new("data");
 
-    // Ensure required extensions exist before running schema import
     sqlx::query("CREATE EXTENSION IF NOT EXISTS pg_trgm")
         .execute(&mut conn)
         .await?;
@@ -60,6 +60,19 @@ pub async fn import_csv() -> Result<(), Box<dyn std::error::Error>> {
     })?;
     let create_sql: String = String::from_utf8_lossy(&create_sql_content).parse()?;
     sqlx::raw_sql(&create_sql).execute(&mut conn).await?;
+
+    info!("Schema creation completed.");
+
+    Ok(())
+}
+
+/// Import CSV data from the data directory.
+/// Requires `create_schema` to have been called beforehand.
+pub async fn import_csv() -> Result<(), Box<dyn std::error::Error>> {
+    let db_url = fetch_database_url();
+    let mut conn = PgConnection::connect(&db_url).await?;
+    let data_path = Path::new("data");
+
     let entries = fs::read_dir(data_path).map_err(|e| {
         tracing::error!("Failed to read data directory: {}", e);
         Box::new(e) as Box<dyn std::error::Error>

--- a/stationapi/src/main.rs
+++ b/stationapi/src/main.rs
@@ -80,22 +80,42 @@ async fn run() -> std::result::Result<(), anyhow::Error> {
         .expect("Failed to install Prometheus exporter");
     info!("Prometheus metrics server listening on {}", metrics_addr);
 
+    // Create schema first so that CSV and GTFS imports can run against existing tables.
+    if let Err(e) = import::create_schema().await {
+        return Err(anyhow::anyhow!("Failed to create schema: {}", e));
+    }
+
+    // Run GTFS import in parallel with CSV import.
+    // GTFS errors are non-fatal; server continues to serve CSV-only data.
+    // The error from import_gtfs is not Send, so stringify it before returning from the task.
+    let gtfs_handle = tokio::spawn(async {
+        info!("Starting GTFS import in background (parallel with CSV)...");
+        import::import_gtfs().await.map_err(|e| e.to_string())
+    });
+
     if let Err(e) = import::import_csv().await {
         return Err(anyhow::anyhow!("Failed to import CSV: {}", e));
     }
 
-    // GTFS import is now done in background after server starts
-    // This allows the server to pass health checks quickly
-    tokio::spawn(async {
-        info!("Starting GTFS import in background...");
-
-        // Import GTFS data (ToeiBus)
-        if let Err(e) = import::import_gtfs().await {
-            warn!(
-                "Failed to import GTFS data: {}. Continuing without GTFS data.",
-                e
-            );
-            return;
+    // After CSV completes, wait for GTFS in background and run integration.
+    // This task lives past server startup; health check passes as soon as CSV is done.
+    tokio::spawn(async move {
+        match gtfs_handle.await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                warn!(
+                    "Failed to import GTFS data: {}. Continuing without GTFS data.",
+                    e
+                );
+                return;
+            }
+            Err(e) => {
+                warn!(
+                    "GTFS import task panicked: {}. Continuing without GTFS data.",
+                    e
+                );
+                return;
+            }
         }
 
         // Integrate GTFS data into stations/lines tables


### PR DESCRIPTION
## 概要

CSV インポートと GTFS インポートを並行実行する構造に再編し、両方の合計所要時間を短縮する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [x] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `import_csv` から `CREATE EXTENSION` および `create_table.sql` の実行を `create_schema` として分離
- `main.rs` で `create_schema` を先行実行した後、GTFS インポートを `tokio::spawn` でバックグラウンド起動し、CSV インポートと並行実行
- CSV 完了時点でサーバ起動・ヘルスチェック通過（従来挙動を維持）
- CSV 完了後に GTFS の `JoinHandle` を待機し、`integrate_gtfs_to_stations` と `ANALYZE` を実行
- GTFS 失敗時の挙動は従来通り `warn` ログのみで継続

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`(`SQLX_OFFLINE=true`)が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 起動時のデータベーススキーマ準備処理を最適化し、CSV および GTFS データインポートの並列実行に対応
  * ヘルスチェック判定をデータベースのテーブル件数に基づいた実装に変更し、サービスの実際の準備状態をより正確に反映

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/StationAPI/pull/1525)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->