### PR TITLE
compose.ymlのPSQLサイドカーにメモリチューニング設定を追加

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -22,6 +22,16 @@ services:
 
   psql:
     image: postgres:18
+    command:
+      - postgres
+      - -c
+      - shared_buffers=384MB
+      - -c
+      - work_mem=64MB
+      - -c
+      - maintenance_work_mem=256MB
+      - -c
+      - effective_cache_size=1GB
     environment:
       POSTGRES_USER: stationapi
       POSTGRES_PASSWORD: stationapi


### PR DESCRIPTION
## 概要

ローカル開発用 `compose.yml` の PostgreSQL サイドカーに `shared_buffers` / `work_mem` / `maintenance_work_mem` / `effective_cache_size` のメモリ系チューニング設定を追加。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [x] その他

## 変更内容

- `compose.yml` の `psql` サービスに `command` を追加し、PostgreSQL の以下のメモリパラメータをデフォルトから引き上げ
  - `shared_buffers=384MB`（デフォルト 128MB）: 内部ページキャッシュ
  - `work_mem=64MB`(デフォルト 4MB): ソート/ハッシュ結合/集約あたりの上限
  - `maintenance_work_mem=256MB`（デフォルト 64MB）: ANALYZE / CREATE INDEX / VACUUM のワークメモリ
  - `effective_cache_size=1GB`: プランナーへの実効キャッシュサイズのヒント
- 動機: ECS 本番タスクでメモリ利用率が 14〜19% 程度で大半が遊んでいたため、サイドカー PSQL がリソースをより活用できるよう調整。`build_stop_route_mapping` や `integrate_gtfs_trip_variations_to_types` の重い CTE クエリ・起動時の ANALYZE 速度・ランタイムの JOIN/ソート性能改善を狙う
- ローカル dev 環境用の設定値。本番 ECS のタスク定義側にも同じ値を当てる前提（タスク定義は repo 外）

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`(`SQLX_OFFLINE=true`)が通ること

`docker compose up` で立ち上げて `SHOW work_mem;` 等で反映確認可能。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * PostgreSQL データベースサービスの構成を更新しました。メモリ管理に関連する複数の新しいパラメータが追加され、サービス起動時に自動的に適用されるようになります。追加される設定項目は `shared_buffers`、`work_mem`、`maintenance_work_mem`、`effective_cache_size` です。既存の環境設定への影響はありません。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/StationAPI/pull/1527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->