### PR TITLE
get_bus_stops_near_stationsのslow statementを部分GiSTインデックスで解消

### DIFF
--- a/data/create_table.sql
+++ b/data/create_table.sql
@@ -507,20 +507,6 @@ BEGIN
 END
 $$;
 
--- Partial GiST index for bus stop nearest-neighbor lookups (get_bus_stops_near_stations)
-DO $$
-BEGIN
-    BEGIN
-        EXECUTE 'CREATE INDEX IF NOT EXISTS idx_performance_stations_bus_point ON public.stations USING gist ((point(lat, lon))) WHERE e_status = 0 AND transport_type = 1';
-    EXCEPTION
-        WHEN undefined_object THEN
-            RAISE NOTICE 'Skipping GiST bus point index; required operator class is unavailable.';
-        WHEN insufficient_privilege THEN
-            RAISE NOTICE 'Skipping GiST bus point index; insufficient privileges.';
-    END;
-END
-$$;
-
 DO $$
 BEGIN
     BEGIN
@@ -628,6 +614,20 @@ END $$;
 
 CREATE INDEX IF NOT EXISTS idx_stations_transport_type ON public.stations USING btree (transport_type);
 CREATE INDEX IF NOT EXISTS idx_lines_transport_type ON public.lines USING btree (transport_type);
+
+-- Partial GiST index for bus stop nearest-neighbor lookups (get_bus_stops_near_stations)
+DO $$
+BEGIN
+    BEGIN
+        EXECUTE 'CREATE INDEX IF NOT EXISTS idx_performance_stations_bus_point ON public.stations USING gist ((point(lat, lon))) WHERE e_status = 0 AND transport_type = 1';
+    EXCEPTION
+        WHEN undefined_object THEN
+            RAISE NOTICE 'Skipping GiST bus point index; required operator class is unavailable.';
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'Skipping GiST bus point index; insufficient privileges.';
+    END;
+END
+$$;
 
 -- ============================================================
 -- GTFS Tables

--- a/data/create_table.sql
+++ b/data/create_table.sql
@@ -108,6 +108,8 @@ DROP INDEX IF EXISTS public.idx_16403_line_aliases_alias_cd;
 
 DROP INDEX IF EXISTS public.idx_performance_stations_point;
 
+DROP INDEX IF EXISTS public.idx_performance_stations_bus_point;
+
 DROP INDEX IF EXISTS public.idx_performance_station_name_trgm;
 
 DROP INDEX IF EXISTS public.idx_performance_station_name_k_trgm;
@@ -501,6 +503,20 @@ BEGIN
             RAISE NOTICE 'Skipping GiST point index; required operator class is unavailable.';
         WHEN insufficient_privilege THEN
             RAISE NOTICE 'Skipping GiST point index; insufficient privileges.';
+    END;
+END
+$$;
+
+-- Partial GiST index for bus stop nearest-neighbor lookups (get_bus_stops_near_stations)
+DO $$
+BEGIN
+    BEGIN
+        EXECUTE 'CREATE INDEX IF NOT EXISTS idx_performance_stations_bus_point ON public.stations USING gist ((point(lat, lon))) WHERE e_status = 0 AND transport_type = 1';
+    EXCEPTION
+        WHEN undefined_object THEN
+            RAISE NOTICE 'Skipping GiST bus point index; required operator class is unavailable.';
+        WHEN insufficient_privilege THEN
+            RAISE NOTICE 'Skipping GiST bus point index; insufficient privileges.';
     END;
 END
 $$;

--- a/stationapi/src/infrastructure/station_repository.rs
+++ b/stationapi/src/infrastructure/station_repository.rs
@@ -1456,7 +1456,7 @@ impl InternalStationRepository {
                 SELECT s.*
                 FROM stations s
                 WHERE s.e_status = 0
-                AND COALESCE(s.transport_type, 0) = $5
+                AND s.transport_type = $5
                 ORDER BY point(s.lat, s.lon) <-> point(ic.lat, ic.lon)
                 LIMIT $4
             ) s


### PR DESCRIPTION
## 概要

`get_bus_stops_near_stations` で発生していた slow statement を、バス停専用の部分 GiST インデックスを追加することで解消する。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [x] バグ修正
- [ ] 新機能
- [x] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

<!-- 変更の詳細を記述してください -->

- `data/create_table.sql`: バス停最近傍検索専用の部分 GiST インデックス `idx_performance_stations_bus_point` を追加（述語: `WHERE e_status = 0 AND transport_type = 1`）。
- `stationapi/src/infrastructure/station_repository.rs`: `get_bus_stops_near_stations` の LATERAL サブクエリ内で `COALESCE(s.transport_type, 0) = $5` を `s.transport_type = $5` に変更。`transport_type` は `NOT NULL` なので挙動は変わらないが、`COALESCE` を残すと上記の部分インデックス述語にマッチせず、プランナがインデックスを選択できない。

### 背景

`get_bus_stops_near_stations` の LATERAL KNN サブクエリは、既存の `idx_performance_stations_point`（`stations USING gist ((point(lat, lon)))`）を使って距離順にスキャンするが、`transport_type = 1` フィルタは post-filter になる。stations テーブルは鉄道駅が大多数・バス停は少数派のため、`LIMIT 50` を満たすまでに多数の鉄道駅を読み飛ばすコストが各座標に対して発生していた。

部分インデックスをバス行に限定することで、KNN スキャン自体がバス停のみを距離順に走るようになり、空振りが消える。`tokio::try_join!` で並列に走る他のクエリ（`get_lines_by_station_group_id_vec_no_types` 等）の待ち時間短縮にもつながる。

### 本番反映時の注意

既存 DB に対しては `data/create_table.sql` 全体を流せないので、別途以下を実行する必要がある。

```sql
CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_performance_stations_bus_point
  ON public.stations USING gist ((point(lat, lon)))
  WHERE e_status = 0 AND transport_type = 1;
```

確認は `EXPLAIN (ANALYZE, BUFFERS)` で `Index Scan using idx_performance_stations_bus_point` が選択されていれば成功。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [x] `cargo fmt --all -- --check` が通ること
- [x] `cargo clippy -- -D warnings` が通ること
- [x] `cargo test`（`SQLX_OFFLINE=true`）が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **パフォーマンス改善**
  * バス停の近傍検索を高速化するため、データベース側の検索最適化を導入しました。

* **Bug Fixes**
  * 駅検索のフィルタリング挙動を修正し、transport_type が未設定の駅を結果から除外するようにして、検索結果の一貫性を向上しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TrainLCD/StationAPI/pull/1528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->