### PR TITLE
データ整合性チェックの data_validator 起動を -p 指定に修正

### DIFF
--- a/.github/workflows/verify_data_Integrity.yml
+++ b/.github/workflows/verify_data_Integrity.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run data validator
         id: validate
         run: |
-          if cargo run --bin data_validator; then
+          if cargo run -p data_validator; then
             echo "result=success" >> "$GITHUB_OUTPUT"
           else
             echo "result=failure" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 概要

データ整合性チェックのワークフロー `verify_data_Integrity.yml` が、`cargo run --bin data_validator` の解決に失敗して必ず落ちる状態になっていたため修正します。

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [ ] ドキュメント
- [x] CI/CD
- [ ] その他

## 変更内容

- `.github/workflows/verify_data_Integrity.yml` の `cargo run --bin data_validator` を `cargo run -p data_validator` に変更

### 原因

Cloudflare Workers 移行 (#1640) でワークスペースのルートが仮想マニフェストから `stationapi-worker` パッケージに変わりました。`cargo run --bin <name>` は default-run パッケージ（= ルートの `stationapi-worker`）の bin ターゲットしか探さないため、以下で失敗します。

```
error: no bin target named `data_validator` in default-run packages
help: available bin in `data_validator` package:
    data_validator
```

このワークフローは `data/*.csv` の変更でしか起動しないため、移行後にデータ変更を含む最初の PR (#1641) で初めて顕在化しました。このまま放置すると **今後のデータ系 PR がすべて赤くなります**。

`AGENTS.md`（`cargo run -p data_validator`）や `Makefile`・`build_worker.yml` の他の呼び出しは既に `-p` 指定なので、それらに揃えました。

### 確認

修正前後をローカルで再現・確認しています。

```
$ cargo run --bin data_validator
error: no bin target named `data_validator` in default-run packages

$ cargo run -p data_validator
[VALID] No errors reported.
```

## テスト

ワークフロー定義のみの変更のため、`cargo` 系のチェックは省略しています（省略: コード変更なし）。`cargo run -p data_validator` が `[VALID] No errors reported.` を返すことはローカルで確認済みです。

- [ ] `make fmt` が通ること
- [ ] `make clippy` が通ること（wasm32 ターゲットを含む）
- [ ] `make test` が通ること

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * データ検証処理の実行方法を更新し、検証ワークフローの安定性を向上しました。
  * 検証結果の出力、成果物の保存、エラー時の処理に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->