### PR TITLE
バージョン管理手順を jj ベースに刷新

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -14,7 +14,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 | 項目 | 既定値 / 推論元 |
 | ---- | ---- |
 | `base` | リポジトリの既定ブランチ（`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`、StationAPI では通常 `dev`） |
-| `head` | 作業コミット `@` に最も近いローカルブックマーク（`jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'`）。該当が無ければ手順 1 で切り出す。**出力が 2 行以上のときは自動選択しない**（同一コミットに複数ブックマークがある、または `@` の上流に head が複数ある場合）。候補を列挙してユーザーに確認してから進める |
+| `head` | 作業コミット `@` に最も近いローカルブックマーク（`jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n") ++ "\n"'`）。該当が無ければ手順 1 で切り出す。**出力が 2 行以上のときは自動選択しない**（同一コミットに複数ブックマークがある、または `@` の上流に head が複数ある場合）。候補を列挙してユーザーに確認してから進める |
 | `title` | 下の「タイトル推論ルール」参照 |
 | `summary` | 空なら「概要」「変更内容」本文はテンプレのコメントのみ残す |
 | `related_issue` | **ユーザー入力を最優先**。指定が `#N`（数値のみ）なら `Closes #N`、`Closes #N` / `Fixes #N` / `Refs #N` 形式ならその接頭語を保って出力。`related_issue` が空のときに限り、コミット件名から `Closes #N` / `Fixes #N` / `Refs #N` を抽出（接頭語を維持。`#N` 単体表記なら `Closes` を補う）。両方とも見つからなければ節のコメントのみ |
@@ -43,8 +43,15 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
   ```bash
   BASE_REF="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)"
   HEAD_REF="$(jj log -r 'heads(::@ & bookmarks())' --no-graph \
-    -T 'local_bookmarks.map(|b| b.name()).join("\n")')"
+    -T 'local_bookmarks.map(|b| b.name()).join("\n") ++ "\n"')"
+
+  # revset は commit ID に解決してから組み立てる（理由は下の項目）
+  BASE_REV="$(jj log -r "$BASE_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
+  HEAD_REV="$(jj log -r "$HEAD_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
   ```
+
+- **ブックマーク名を jj の revset へ直接連結しない。** `&` と `|` は git の ref 名には使えるが jj では revset の演算子で、`"$BASE_REF@origin..$HEAD_REF@origin"` のような連結は `Error: Revision ... doesn't exist` で落ちる。`jj bookmark create` 自身がこの種の名前を拒否するため発生源は Git 側で作られた／fetch されたブランチに限られるが、上のように **`BASE_REV` / `HEAD_REV`（commit ID）へ一度解決し、以降の revset は commit ID だけで組み立てる**。`gh` に渡すのは GitHub 上のブランチ名なので `$BASE_REF` / `$HEAD_REF` のままでよい。
+- **`HEAD_REF` が `^[A-Za-z0-9._/-]+$` に一致しない場合は自動で進めない。** `local_bookmarks.map(|b| b.name())` は要引用の名前を revset 用の引用付き（`"feature/x&dev"`、内部の `"` は `\"`）で返す。この表記は revset では正しいが `gh --head` やファイル名 slug には使えないため、一致しない値が返ったらユーザーに正しいブランチ名を確認する。
 
 ## 手順
 
@@ -91,9 +98,9 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
    - コミットとファイル差分の**両方**を確認する。`jj log` はコミットの有無しか見ないため、空コミットだけが載ったブックマークが通過してしまう。
 
      ```bash
-     jj log -r "$BASE_REF@origin..$HEAD_REF@origin" --no-graph \
+     jj log -r "$BASE_REV..$HEAD_REV" --no-graph \
        -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"'
-     jj diff --name-only --from "$BASE_REF@origin" --to "$HEAD_REF@origin"
+     jj diff --name-only --from "$BASE_REV" --to "$HEAD_REV"
      ```
 
      コミット一覧が空、または `jj diff --name-only` の出力が空の場合は「PR 対象の差分が無い」と報告し、**既存 PR の検索へ進まずに中断する**。
@@ -105,8 +112,8 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
    `<base>@origin..<head>@origin` のコミット件名と変更ファイルを取得:
    ```bash
-   jj log -r "$BASE_REF@origin..$HEAD_REF@origin" --no-graph -T 'description.first_line() ++ "\n"'
-   jj diff --name-only --from "$BASE_REF@origin" --to "$HEAD_REF@origin"
+   jj log -r "$BASE_REV..$HEAD_REV" --no-graph -T 'description.first_line() ++ "\n"'
+   jj diff --name-only --from "$BASE_REV" --to "$HEAD_REV"
    ```
 
    **大原則: 判定はアプリ挙動／データに対する変更かどうかで決める**。下の「コード本体パス」が一切変わっていない場合、「バグ修正」「新機能」「リファクタリング」は OFF（コミット件名に `fix` / `feat` 等の語があっても）。スキル・設定・ドキュメントのメタ変更を「新機能」と誤分類しないための安全弁。「データの修正・追加」は `data/**` の変更を独立に判定する（後述「変更ファイルパスベース」「コミット件名ベース」を参照）。

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -119,7 +119,8 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
 2. **状態確認とモード決定（新規作成 / 更新）**
    - `jj git fetch` を実行（remote bookmark をまとめて更新する）。**fetch は remote bookmark を動かすため、前提条件で解決した `BASE_REV` / `HEAD_REV` は fetch 後に必ず解決し直す**（古い commit ID のまま進むと差分の検出範囲がずれる）。
-   - **`BASE_REV` / `HEAD_REV` は origin 側の位置なので、ローカルの `HEAD_REF` がそれより先行していないかを機械的に確かめる。** 一致しなければ未 push のコミットがあり、そのまま進むとその分を含まない範囲で PR が組み上がる。検出したら push の可否をユーザーに確認して中断する（勝手に push しない）。ブックマークは自動追従しないので、`jj commit` 後に `jj bookmark set` を忘れた場合もここに現れる。
+   - **`BASE_REV` / `HEAD_REV` は origin 側の位置なので、ローカルの `HEAD_REF` がそれと一致することを機械的に確かめる。** 一致しなければ未 push のコミットがあり、そのまま進むとその分を含まない範囲で PR が組み上がる。検出したら push の可否をユーザーに確認して中断する（勝手に push しない）。ブックマークは自動追従しないので、`jj commit` 後に `jj bookmark set` を忘れた場合もここに現れる。
+   - **ローカルに `HEAD_REF` が無い場合も中断する。** 空は「未 push が無い」証拠ではなく、単に検証できていない状態（ローカルで削除済み、あるいは origin にしか無いブックマークを `head` に指定した、など）。`jj bookmark track "<名前>@origin"` でローカルへ取り込んでからやり直す。
    - コミットとファイル差分の**両方**を確認する。`jj log` はコミットの有無しか見ないため、空コミットだけが載ったブックマークが通過してしまう。
 
      ```bash
@@ -127,11 +128,17 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
      BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1   # 前提条件で定義したヘルパ
      HEAD_REV="$(resolve_remote_rev "$HEAD_REF")" || exit 1
 
-     # ローカルの HEAD_REF が origin より先行していないか（未 push の変更が無いか）確認する。
-     # HEAD_REF は resolve_remote_rev の case で検証済み。ローカルに無ければ空が返る
+     # ローカルの HEAD_REF を解決し、origin の先端と一致することを確認する。
+     # HEAD_REF は resolve_remote_rev の case で検証済み
      HEAD_LOCAL_REV="$(jj log -r "bookmarks(exact:\"$HEAD_REF\")" --no-graph \
        -T 'commit_id ++ "\n"')"
-     if [ -n "$HEAD_LOCAL_REV" ] && [ "$HEAD_LOCAL_REV" != "$HEAD_REV" ]; then
+     # 該当が無くても終了コードは 0 なので、|| ではなく中身で判定する
+     if [ -z "$HEAD_LOCAL_REV" ]; then
+       printf 'ローカルに %s が無い。origin だけを見て組むと一致を検証できない。\n' "$HEAD_REF" >&2
+       printf 'jj bookmark track "%s@origin" でトラックしてからやり直す。\n' "$HEAD_REF" >&2
+       exit 1
+     fi
+     if [ "$HEAD_LOCAL_REV" != "$HEAD_REV" ]; then
        printf 'ローカル %s が origin と一致しない:\n  local  = %s\n  origin = %s\n' \
          "$HEAD_REF" "$HEAD_LOCAL_REV" "$HEAD_REV" >&2
        exit 1   # 未 push の変更がある。push の可否をユーザーに確認してから進む

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -37,7 +37,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 - カレントディレクトリが `jj root` で解決できるリポジトリ内。
 - **バージョン管理は jj で行う。** このリポジトリは colocated（`.jj/` と `.git/` が同居）なので `git` も動いてしまうが、書き込み系の git コマンド（`commit` / `switch` / `branch` / `push` など）は使わない。jj が次回起動時に Git の ref を再取り込みし、変更が破棄されるか divergent change として二重化する。詳細は `AGENTS.md` の **Version Control (Jujutsu)** を参照。
 - `gh` CLI が認証済み（PR 操作だけは従来どおり `gh`）。
-- `head` ブックマークが origin に push 済み。未 push の場合はユーザーに push の可否を確認する（勝手に push しない）。
+- `head` ブックマークが origin に push 済み。未 push の場合はユーザーに push の可否を確認する（勝手に push しない）。散文の前提で終わらせず、手順 2 でローカルと origin の commit ID を突き合わせて機械的に検出する。
 - **ref 名をシェルソースへ直接埋め込まない。** 本書の `<base>` / `<head>` は説明用のプレースホルダ。実際のコマンドでは値を `BASE_REF` / `HEAD_REF` に取り込み、以降は必ず `"$BASE_REF"` / `"$HEAD_REF"` で参照する。jj のブックマーク名は git の ref 名と同じ規則で、`'` / `$( )` / バッククォート / `;` を含められるため、リテラルを直接置換すると構文が壊れるか、意図しないコマンドが実行される。値はコマンド出力から取り込む（ユーザー指定がある場合のみ、その値を代入する）:
 
   ```bash
@@ -119,12 +119,23 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
 2. **状態確認とモード決定（新規作成 / 更新）**
    - `jj git fetch` を実行（remote bookmark をまとめて更新する）。**fetch は remote bookmark を動かすため、前提条件で解決した `BASE_REV` / `HEAD_REV` は fetch 後に必ず解決し直す**（古い commit ID のまま進むと差分の検出範囲がずれる）。
+   - **`BASE_REV` / `HEAD_REV` は origin 側の位置なので、ローカルの `HEAD_REF` がそれより先行していないかを機械的に確かめる。** 一致しなければ未 push のコミットがあり、そのまま進むとその分を含まない範囲で PR が組み上がる。検出したら push の可否をユーザーに確認して中断する（勝手に push しない）。ブックマークは自動追従しないので、`jj commit` 後に `jj bookmark set` を忘れた場合もここに現れる。
    - コミットとファイル差分の**両方**を確認する。`jj log` はコミットの有無しか見ないため、空コミットだけが載ったブックマークが通過してしまう。
 
      ```bash
      jj git fetch
      BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1   # 前提条件で定義したヘルパ
      HEAD_REV="$(resolve_remote_rev "$HEAD_REF")" || exit 1
+
+     # ローカルの HEAD_REF が origin より先行していないか（未 push の変更が無いか）確認する。
+     # HEAD_REF は resolve_remote_rev の case で検証済み。ローカルに無ければ空が返る
+     HEAD_LOCAL_REV="$(jj log -r "bookmarks(exact:\"$HEAD_REF\")" --no-graph \
+       -T 'commit_id ++ "\n"')"
+     if [ -n "$HEAD_LOCAL_REV" ] && [ "$HEAD_LOCAL_REV" != "$HEAD_REV" ]; then
+       printf 'ローカル %s が origin と一致しない:\n  local  = %s\n  origin = %s\n' \
+         "$HEAD_REF" "$HEAD_LOCAL_REV" "$HEAD_REV" >&2
+       exit 1   # 未 push の変更がある。push の可否をユーザーに確認してから進む
+     fi
 
      jj log -r "$BASE_REV..$HEAD_REV" --no-graph \
        -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"'

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -14,7 +14,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 | 項目 | 既定値 / 推論元 |
 | ---- | ---- |
 | `base` | リポジトリの既定ブランチ（`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`、StationAPI では通常 `dev`） |
-| `head` | カレントブランチ（`git rev-parse --abbrev-ref HEAD`） |
+| `head` | 作業コミット `@` に最も近いローカルブックマーク（`jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'`）。該当が無ければ手順 1 で切り出す |
 | `title` | 下の「タイトル推論ルール」参照 |
 | `summary` | 空なら「概要」「変更内容」本文はテンプレのコメントのみ残す |
 | `related_issue` | **ユーザー入力を最優先**。指定が `#N`（数値のみ）なら `Closes #N`、`Closes #N` / `Fixes #N` / `Refs #N` 形式ならその接頭語を保って出力。`related_issue` が空のときに限り、コミット件名から `Closes #N` / `Fixes #N` / `Refs #N` を抽出（接頭語を維持。`#N` 単体表記なら `Closes` を補う）。両方とも見つからなければ節のコメントのみ |
@@ -23,7 +23,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
 ### タイトル推論ルール
 
-`origin/<base>..origin/<head>` のコミット件名を対象に、以下を順に試す:
+`<base>@origin..<head>@origin`（jj revset）のコミット件名を対象に、以下を順に試す:
 
 1. **コミット 1 件のみ**: その件名をそのまま使う。
 2. **コミット複数・共通テーマあり**: 最新コミットの件名、もしくは件名群を要約した日本語の単文を使う。
@@ -34,20 +34,21 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
 ## 前提条件
 
-- カレントディレクトリが `git rev-parse --show-toplevel` で解決できるリポジトリ内。
-- `gh` CLI が認証済み。
-- `head` ブランチが origin に push 済み。未 push の場合はユーザーに push の可否を確認する（勝手に push しない）。
+- カレントディレクトリが `jj root` で解決できるリポジトリ内。
+- **バージョン管理は jj で行う。** このリポジトリは colocated（`.jj/` と `.git/` が同居）なので `git` も動いてしまうが、書き込み系の git コマンド（`commit` / `switch` / `branch` / `push` など）は使わない。jj が次回起動時に Git の ref を再取り込みし、変更が破棄されるか divergent change として二重化する。詳細は `AGENTS.md` の **Version Control (Jujutsu)** を参照。
+- `gh` CLI が認証済み（PR 操作だけは従来どおり `gh`）。
+- `head` ブックマークが origin に push 済み。未 push の場合はユーザーに push の可否を確認する（勝手に push しない）。
 
 ## 手順
 
-1. **head / base の整合性チェックと自動ブランチ切り出し**
+1. **head / base の整合性チェックと自動ブックマーク切り出し**
 
-   `base == head` になるケース（例: `dev` に居てデフォルト base も `dev`）は、そのまま進めると PR が作れない。以下のいずれかで救済する:
+   `head` が `base` と同じブックマーク（例: `dev` の上で作業していて base も `dev`）や、そもそもブックマークが無い状態は、そのまま進めると PR が作れない。`jj status` で `@` の内容を確認し、以下のいずれかで救済する:
 
-   - 作業中の変更（staged / unstaged / 直近の未 push コミット）がある場合、**新しいブランチを切ってそこに退避**してから続行する。
-   - 何の変更も無い場合は「PR 対象の差分が無い」と報告して中断する。
+   - `@` に変更がある、または未 push のコミットがある場合、**新しいブックマークを作ってそこに載せる**。
+   - 何の変更も無い（`@` が empty で `trunk()` と同じ）場合は「PR 対象の差分が無い」と報告して中断する。
 
-   **ブランチ名の推論**（`CONTRIBUTING.md` の命名規則に従う）:
+   **ブックマーク名の推論**（`CONTRIBUTING.md` の命名規則に従う。git のブランチ名とそのまま対応する）:
 
    | プレフィックス | 採用条件 |
    | ---- | ---- |
@@ -61,36 +62,36 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
    切り出し手順:
    ```bash
-   git switch -c <inferred-branch>
-   # 未コミットなら:
-   git add -u                       # 追跡済みの staged/unstaged をまとめてステージ
-   # 未追跡ファイルも退避対象なら明示的にパス指定で追加（`git add -A` / `.` は使わない）:
-   #   git add path/to/untracked-file ...
-   git commit                       # コミットメッセージは日本語単文
-   git push -u origin <inferred-branch>
+   jj status                                          # @ に何が入っているか必ず先に確認
+   jj commit -m "<日本語単文>"                          # @ に説明を付けて確定し、新しい空の @ を作る
+   jj bookmark create <inferred-bookmark> -r @-        # 直前に確定したコミットにブックマークを置く
+   jj git push -b <inferred-bookmark>
    ```
+   - **jj にステージング領域は無く、未追跡ファイルという概念も無い**（`snapshot.auto-track = "all()"`）。`.gitignore` に載っていない一時ファイルは黙って `@` に入るので、`jj status` の出力を読んでから確定する。関係ないファイルは `jj restore <path>` で戻すか、`jj split` で別コミットに分ける。`git add` に相当する「一部だけ含める」操作は無い。
+   - 変更が既に `@` ではなく確定済みコミット側にある場合は `jj commit` を飛ばし、`jj bookmark create <inferred-bookmark> -r <rev>` で直接そのコミットに置く。
+   - ブックマークは自動で追従しないので、追加コミット後は `jj bookmark set <inferred-bookmark> -r @-` で必ず動かす。忘れると push が空振りする。
    - コミット前に下記の品質チェックを通す（`CONTRIBUTING.md` ルール、手順 3 で定義する「コード本体パス」に変更が無ければ省略可）:
      - `cargo fmt --all -- --check`
      - `make clippy`
      - `make test`
    - データのみの変更（`data/*.csv` 等）を含む場合は `cargo run -p data_validator` も流す。
-   - push は新規ブランチなので安全だが、実行前にユーザーへ要約（ブランチ名・含めるファイル・コミットメッセージ案）を提示して承認を取る。
+   - push は新規ブックマークなので安全だが、実行前にユーザーへ要約（ブックマーク名・含めるファイル・コミットメッセージ案）を提示して承認を取る。未トラックのブックマークは `-b` 指定で自動的にトラックされる。
 
    以降の手順では推論後の head を使う。
 
 2. **状態確認とモード決定（新規作成 / 更新）**
-   - `git fetch origin <base> <head>` を実行。
-   - `git log --oneline origin/<base>..origin/<head>` で差分があることを確認。無ければ中断して報告。
+   - `jj git fetch` を実行（remote bookmark をまとめて更新する）。
+   - `jj log -r '<base>@origin..<head>@origin' --no-graph -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"'` で差分があることを確認。無ければ中断して報告。
    - `gh pr list --base <base> --head <head> --state open --json number,url,body` で既存 open PR を確認。
      - **存在しない場合**: 新規作成モード。以降、手順 5 で `gh pr create`。
      - **存在する場合**: 更新モード。既存本文を最新差分で再生成する。以降、手順 5 で `gh pr edit`。タイトルは既存を**原則尊重**（ユーザー推論より優先）。ただし手順 5 の整合性チェックで主題が大きくズレていると判断した場合のみ更新案を提示する。
 
 3. **変更の種類を判定**
 
-   `origin/<base>..origin/<head>` のコミット件名と変更ファイルを取得:
+   `<base>@origin..<head>@origin` のコミット件名と変更ファイルを取得:
    ```bash
-   git log --pretty=%s origin/<base>..origin/<head>
-   git diff --name-only origin/<base>..origin/<head>
+   jj log -r '<base>@origin..<head>@origin' --no-graph -T 'description.first_line() ++ "\n"'
+   jj diff --name-only --from '<base>@origin' --to '<head>@origin'
    ```
 
    **大原則: 判定はアプリ挙動／データに対する変更かどうかで決める**。下の「コード本体パス」が一切変わっていない場合、「バグ修正」「新機能」「リファクタリング」は OFF（コミット件名に `fix` / `feat` 等の語があっても）。スキル・設定・ドキュメントのメタ変更を「新機能」と誤分類しないための安全弁。「データの修正・追加」は `data/**` の変更を独立に判定する（後述「変更ファイルパスベース」「コミット件名ベース」を参照）。
@@ -181,14 +182,14 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
       - 連続した `_` は 1 つに畳み、先頭・末尾の `_` は除去
       - 必要なら長さを 100〜200 文字程度に切り詰める
 
-      生のブランチ名を直結するとサブディレクトリ解釈や制御文字混入で Write／削除が失敗する。バッククォートは **素のまま** 書く。escape しない。
+      生のブックマーク名を直結するとサブディレクトリ解釈や制御文字混入で Write／削除が失敗する。バッククォートは **素のまま** 書く。escape しない。
    2. 下の `gh` コマンドをサブシェル内で `trap` と一緒に実行する。`gh` の成功・失敗に関わらず `EXIT` / `INT` / `TERM` のどれでも一時ファイルを確実に削除されるようにする（`&&` で `rm` を繋ぐだけだと失敗時に `/tmp` にゴミが残る）。
    3. `gh` 呼び出しと `rm`（を含む `trap`）は Bash tool の 1 呼び出し内で完結させる。別呼び出しで後片付けすると、前段の呼び出しがエラー／中断で終わった場合にクリーンアップが実行されない。
 
    **新規作成モード**
 
    ```bash
-   # ref 名をファイル名として安全な集合（A-Za-z0-9._-）にスラッグ化
+   # ref 名（ブックマーク名）をファイル名として安全な集合（A-Za-z0-9._-）にスラッグ化
    REF_SLUG="$(printf '%s' '<head>' \
      | tr -d '\r\n' \
      | tr -c 'A-Za-z0-9._-' '_' \
@@ -231,8 +232,10 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 ## 注意事項
 
 - テンプレの節構成は改変しない。追加・削除はメンテナ承認が必要。
-- `git push --no-verify` や force push はしない。push が必要ならユーザーに確認。
+- バージョン管理の操作は `jj` で行い、書き込み系の `git` コマンドは使わない（colocated リポジトリなので動いてしまうが、jj 側と食い違う）。
+- **push 済みのコミットを勝手に書き換えない。** `jj describe` / `jj squash` / `jj rebase` は履歴をその場で書き換え、次の `jj git push` が force-with-lease 相当でリモートのブックマークを巻き戻す。git の force push と同じ扱いで、必ずユーザーに確認する。
+- 操作をやり直したいときは手作業で戻さず `jj undo`（直前の操作を取り消す）／`jj op log`（操作履歴）を使う。
 - 既存 open PR を上書きしない（重複作成禁止）。
-- ブランチプレフィックスは `feature/` / `fix/` / `data/` / `chore/` / `release/` のみ使用（`pr-labeler.yml` のラベル自動付与に直結する）。
+- ブックマークのプレフィックスは `feature/` / `fix/` / `data/` / `chore/` / `release/` のみ使用（`pr-labeler.yml` のラベル自動付与に直結する）。
 - 本文は `gh pr create --body` / `gh pr edit --body` のようにインラインで渡さない。必ず `--body-file` で一時ファイル経由で渡す（バッククォートなど特殊文字の escape 事故を構造的に防ぐため）。
 - データ変更を伴う PR では `cargo run -p data_validator` の実行結果を「テスト」または「変更内容」節に追記すると `AGENTS.md` のガイドライン（変更内容と検証コマンドの記録）に沿う。

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -53,13 +53,22 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
   fi
   HEAD_REF="$HEAD_CANDIDATES"
 
-  # ref 名を検証し、origin 上のブックマークを commit ID へ解決する。
-  # BASE_REF / HEAD_REF に同じ規則を適用する（理由は下の 3 項目）
-  resolve_remote_rev() {
+  # ref 名の文字種を検証する。gh --head・ファイル名 slug・revset の
+  # 文字列リテラルのすべてで安全に使える集合か（理由は下の 3 項目）。
+  # BASE_REF / HEAD_REF に同じ規則を適用する
+  validate_ref() {
     case "$1" in
       '' | *[!A-Za-z0-9._/-]*)
         printf 'ref 名に想定外の文字が含まれる: %s\n' "$1" >&2; return 1 ;;
     esac
+  }
+  validate_ref "$BASE_REF" || exit 1
+  validate_ref "$HEAD_REF" || exit 1
+
+  # origin 上のブックマークを commit ID へ解決する。
+  # 実際の解決は fetch 後（手順 2）に一度だけ行うので、ここでは定義のみ
+  resolve_remote_rev() {
+    validate_ref "$1" || return 1
     rev="$(jj log -r "remote_bookmarks(exact:\"$1\", exact:\"origin\")" \
       --no-graph -T 'commit_id ++ "\n"')"
     if [ "$(printf '%s\n' "$rev" | grep -c .)" -ne 1 ]; then
@@ -67,9 +76,6 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
     fi
     printf '%s\n' "$rev"
   }
-
-  BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1
-  HEAD_REV="$(resolve_remote_rev "$HEAD_REF")" || exit 1
   ```
 
 - **ブックマーク名を jj の revset へ直接連結しない。** `&` と `|` は git の ref 名には使えるが jj では revset の演算子で、`"$BASE_REF@origin..$HEAD_REF@origin"` のような連結は `Error: Revision ... doesn't exist` で落ちる。`jj bookmark create` 自身がこの種の名前を拒否するため発生源は Git 側で作られた／fetch されたブランチに限られるが、上のように **`BASE_REV` / `HEAD_REV`（commit ID）へ一度解決し、以降の revset は commit ID だけで組み立てる**。`gh` に渡すのは GitHub 上のブランチ名なので `$BASE_REF` / `$HEAD_REF` のままでよい。
@@ -118,7 +124,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
    以降の手順では推論後の head を使う。
 
 2. **状態確認とモード決定（新規作成 / 更新）**
-   - `jj git fetch` を実行（remote bookmark を更新する）。**fetch は remote bookmark を動かすため、前提条件で解決した `BASE_REV` / `HEAD_REV` は fetch 後に必ず解決し直す**（古い commit ID のまま進むと差分の検出範囲がずれる）。
+   - `jj git fetch` を実行（remote bookmark を更新する）。**`BASE_REV` / `HEAD_REV` の解決は必ず fetch の後に行う。** fetch は remote bookmark を動かすので、先に解決すると古い commit ID で差分を測ることになる。加えて `remote_bookmarks()` が読むのは jj が記録している remote の状態なので、まだ fetch していないブックマークは解決できない。前提条件で済ませておくのは ref 名の文字種検証までにとどめる。
    - **fetch 対象は `--remote` と `--branch` で明示する。** 引数無しの `jj git fetch` は remote を `git.fetch`、ブックマークを `remotes.<name>.fetch-bookmarks` の設定から決める。これらはユーザーグローバル設定なので、別マシンでは `origin` や対象ブックマークが更新されないことがあり、その場合 `@origin` を読む後続の解決と一致検査が古い値のまま通ってしまう。`--branch` のパターンは既定が glob なので `exact:` を付ける。
    - **`BASE_REV` / `HEAD_REV` は origin 側の位置なので、ローカルの `HEAD_REF` がそれと一致することを機械的に確かめる。** 一致しなければ未 push のコミットがあり、そのまま進むとその分を含まない範囲で PR が組み上がる。検出したら push の可否をユーザーに確認して中断する（勝手に push しない）。ブックマークは自動追従しないので、`jj commit` 後に `jj bookmark set` を忘れた場合もここに現れる。
    - **ローカルに `HEAD_REF` が無い場合も中断する。** 空は「未 push が無い」証拠ではなく、単に検証できていない状態（ローカルで削除済み、あるいは origin にしか無いブックマークを `head` に指定した、など）。`jj bookmark track "<名前>@origin"` でローカルへ取り込んでからやり直す。
@@ -130,7 +136,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
      jj git fetch --remote origin \
        --branch "exact:$BASE_REF" \
        --branch "exact:$HEAD_REF"
-     BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1   # 前提条件で定義したヘルパ
+     BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1   # 前提条件で定義したヘルパ。解決はここが最初
      HEAD_REV="$(resolve_remote_rev "$HEAD_REF")" || exit 1
 
      # ローカルの HEAD_REF を解決し、origin の先端と一致することを確認する。

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -42,8 +42,16 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
   ```bash
   BASE_REF="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)"
-  HEAD_REF="$(jj log -r 'heads(::@ & bookmarks())' --no-graph \
+
+  # 候補は一度 HEAD_CANDIDATES に受ける。0 件／2 件以上をそのまま代入すると、
+  # 内部改行を含んだ値が gh --head や slug 処理へそのまま流れる
+  HEAD_CANDIDATES="$(jj log -r 'heads(::@ & bookmarks())' --no-graph \
     -T 'local_bookmarks.map(|b| b.name()).join("\n") ++ "\n"')"
+  if [ "$(printf '%s\n' "$HEAD_CANDIDATES" | grep -c .)" -ne 1 ]; then
+    printf '%s\n' "$HEAD_CANDIDATES"   # 候補を列挙してユーザーに確認する（自動選択しない）
+    exit 1
+  fi
+  HEAD_REF="$HEAD_CANDIDATES"
 
   # revset は commit ID に解決してから組み立てる（理由は下の項目）
   BASE_REV="$(jj log -r "$BASE_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
@@ -94,10 +102,14 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
    以降の手順では推論後の head を使う。
 
 2. **状態確認とモード決定（新規作成 / 更新）**
-   - `jj git fetch` を実行（remote bookmark をまとめて更新する）。
+   - `jj git fetch` を実行（remote bookmark をまとめて更新する）。**fetch は remote bookmark を動かすため、前提条件で解決した `BASE_REV` / `HEAD_REV` は fetch 後に必ず解決し直す**（古い commit ID のまま進むと差分の検出範囲がずれる）。
    - コミットとファイル差分の**両方**を確認する。`jj log` はコミットの有無しか見ないため、空コミットだけが載ったブックマークが通過してしまう。
 
      ```bash
+     jj git fetch
+     BASE_REV="$(jj log -r "$BASE_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
+     HEAD_REV="$(jj log -r "$HEAD_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
+
      jj log -r "$BASE_REV..$HEAD_REV" --no-graph \
        -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"'
      jj diff --name-only --from "$BASE_REV" --to "$HEAD_REV"

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -14,7 +14,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 | 項目 | 既定値 / 推論元 |
 | ---- | ---- |
 | `base` | リポジトリの既定ブランチ（`gh repo view --json defaultBranchRef -q .defaultBranchRef.name`、StationAPI では通常 `dev`） |
-| `head` | 作業コミット `@` に最も近いローカルブックマーク（`jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'`）。該当が無ければ手順 1 で切り出す |
+| `head` | 作業コミット `@` に最も近いローカルブックマーク（`jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'`）。該当が無ければ手順 1 で切り出す。**出力が 2 行以上のときは自動選択しない**（同一コミットに複数ブックマークがある、または `@` の上流に head が複数ある場合）。候補を列挙してユーザーに確認してから進める |
 | `title` | 下の「タイトル推論ルール」参照 |
 | `summary` | 空なら「概要」「変更内容」本文はテンプレのコメントのみ残す |
 | `related_issue` | **ユーザー入力を最優先**。指定が `#N`（数値のみ）なら `Closes #N`、`Closes #N` / `Fixes #N` / `Refs #N` 形式ならその接頭語を保って出力。`related_issue` が空のときに限り、コミット件名から `Closes #N` / `Fixes #N` / `Refs #N` を抽出（接頭語を維持。`#N` 単体表記なら `Closes` を補う）。両方とも見つからなければ節のコメントのみ |
@@ -38,6 +38,13 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 - **バージョン管理は jj で行う。** このリポジトリは colocated（`.jj/` と `.git/` が同居）なので `git` も動いてしまうが、書き込み系の git コマンド（`commit` / `switch` / `branch` / `push` など）は使わない。jj が次回起動時に Git の ref を再取り込みし、変更が破棄されるか divergent change として二重化する。詳細は `AGENTS.md` の **Version Control (Jujutsu)** を参照。
 - `gh` CLI が認証済み（PR 操作だけは従来どおり `gh`）。
 - `head` ブックマークが origin に push 済み。未 push の場合はユーザーに push の可否を確認する（勝手に push しない）。
+- **ref 名をシェルソースへ直接埋め込まない。** 本書の `<base>` / `<head>` は説明用のプレースホルダ。実際のコマンドでは値を `BASE_REF` / `HEAD_REF` に取り込み、以降は必ず `"$BASE_REF"` / `"$HEAD_REF"` で参照する。jj のブックマーク名は git の ref 名と同じ規則で、`'` / `$( )` / バッククォート / `;` を含められるため、リテラルを直接置換すると構文が壊れるか、意図しないコマンドが実行される。値はコマンド出力から取り込む（ユーザー指定がある場合のみ、その値を代入する）:
+
+  ```bash
+  BASE_REF="$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)"
+  HEAD_REF="$(jj log -r 'heads(::@ & bookmarks())' --no-graph \
+    -T 'local_bookmarks.map(|b| b.name()).join("\n")')"
+  ```
 
 ## 手順
 
@@ -81,8 +88,16 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
 2. **状態確認とモード決定（新規作成 / 更新）**
    - `jj git fetch` を実行（remote bookmark をまとめて更新する）。
-   - `jj log -r '<base>@origin..<head>@origin' --no-graph -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"'` で差分があることを確認。無ければ中断して報告。
-   - `gh pr list --base <base> --head <head> --state open --json number,url,body` で既存 open PR を確認。
+   - コミットとファイル差分の**両方**を確認する。`jj log` はコミットの有無しか見ないため、空コミットだけが載ったブックマークが通過してしまう。
+
+     ```bash
+     jj log -r "$BASE_REF@origin..$HEAD_REF@origin" --no-graph \
+       -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"'
+     jj diff --name-only --from "$BASE_REF@origin" --to "$HEAD_REF@origin"
+     ```
+
+     コミット一覧が空、または `jj diff --name-only` の出力が空の場合は「PR 対象の差分が無い」と報告し、**既存 PR の検索へ進まずに中断する**。
+   - `gh pr list --base "$BASE_REF" --head "$HEAD_REF" --state open --json number,url,body` で既存 open PR を確認。
      - **存在しない場合**: 新規作成モード。以降、手順 5 で `gh pr create`。
      - **存在する場合**: 更新モード。既存本文を最新差分で再生成する。以降、手順 5 で `gh pr edit`。タイトルは既存を**原則尊重**（ユーザー推論より優先）。ただし手順 5 の整合性チェックで主題が大きくズレていると判断した場合のみ更新案を提示する。
 
@@ -90,8 +105,8 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
    `<base>@origin..<head>@origin` のコミット件名と変更ファイルを取得:
    ```bash
-   jj log -r '<base>@origin..<head>@origin' --no-graph -T 'description.first_line() ++ "\n"'
-   jj diff --name-only --from '<base>@origin' --to '<head>@origin'
+   jj log -r "$BASE_REF@origin..$HEAD_REF@origin" --no-graph -T 'description.first_line() ++ "\n"'
+   jj diff --name-only --from "$BASE_REF@origin" --to "$HEAD_REF@origin"
    ```
 
    **大原則: 判定はアプリ挙動／データに対する変更かどうかで決める**。下の「コード本体パス」が一切変わっていない場合、「バグ修正」「新機能」「リファクタリング」は OFF（コミット件名に `fix` / `feat` 等の語があっても）。スキル・設定・ドキュメントのメタ変更を「新機能」と誤分類しないための安全弁。「データの修正・追加」は `data/**` の変更を独立に判定する（後述「変更ファイルパスベース」「コミット件名ベース」を参照）。
@@ -190,7 +205,7 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
    ```bash
    # ref 名（ブックマーク名）をファイル名として安全な集合（A-Za-z0-9._-）にスラッグ化
-   REF_SLUG="$(printf '%s' '<head>' \
+   REF_SLUG="$(printf '%s' "$HEAD_REF" \
      | tr -d '\r\n' \
      | tr -c 'A-Za-z0-9._-' '_' \
      | sed -E 's/_+/_/g; s/^_+//; s/_+$//' \
@@ -200,8 +215,8 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
    (
      trap 'rm -f "$BODY_FILE"' EXIT INT TERM
      gh pr create \
-       --base "<base>" \
-       --head "<head>" \
+       --base "$BASE_REF" \
+       --head "$HEAD_REF" \
        --title "<title>" \
        --assignee TinyKitten \
        [--label "<label1>" --label "<label2>" ...] \

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -118,13 +118,18 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
    以降の手順では推論後の head を使う。
 
 2. **状態確認とモード決定（新規作成 / 更新）**
-   - `jj git fetch` を実行（remote bookmark をまとめて更新する）。**fetch は remote bookmark を動かすため、前提条件で解決した `BASE_REV` / `HEAD_REV` は fetch 後に必ず解決し直す**（古い commit ID のまま進むと差分の検出範囲がずれる）。
+   - `jj git fetch` を実行（remote bookmark を更新する）。**fetch は remote bookmark を動かすため、前提条件で解決した `BASE_REV` / `HEAD_REV` は fetch 後に必ず解決し直す**（古い commit ID のまま進むと差分の検出範囲がずれる）。
+   - **fetch 対象は `--remote` と `--branch` で明示する。** 引数無しの `jj git fetch` は remote を `git.fetch`、ブックマークを `remotes.<name>.fetch-bookmarks` の設定から決める。これらはユーザーグローバル設定なので、別マシンでは `origin` や対象ブックマークが更新されないことがあり、その場合 `@origin` を読む後続の解決と一致検査が古い値のまま通ってしまう。`--branch` のパターンは既定が glob なので `exact:` を付ける。
    - **`BASE_REV` / `HEAD_REV` は origin 側の位置なので、ローカルの `HEAD_REF` がそれと一致することを機械的に確かめる。** 一致しなければ未 push のコミットがあり、そのまま進むとその分を含まない範囲で PR が組み上がる。検出したら push の可否をユーザーに確認して中断する（勝手に push しない）。ブックマークは自動追従しないので、`jj commit` 後に `jj bookmark set` を忘れた場合もここに現れる。
    - **ローカルに `HEAD_REF` が無い場合も中断する。** 空は「未 push が無い」証拠ではなく、単に検証できていない状態（ローカルで削除済み、あるいは origin にしか無いブックマークを `head` に指定した、など）。`jj bookmark track "<名前>@origin"` でローカルへ取り込んでからやり直す。
    - コミットとファイル差分の**両方**を確認する。`jj log` はコミットの有無しか見ないため、空コミットだけが載ったブックマークが通過してしまう。
 
      ```bash
-     jj git fetch
+     # 設定（git.fetch / remotes.<name>.fetch-bookmarks）に左右されないよう
+     # remote と対象ブックマークを明示する
+     jj git fetch --remote origin \
+       --branch "exact:$BASE_REF" \
+       --branch "exact:$HEAD_REF"
      BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1   # 前提条件で定義したヘルパ
      HEAD_REV="$(resolve_remote_rev "$HEAD_REF")" || exit 1
 

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -53,13 +53,29 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
   fi
   HEAD_REF="$HEAD_CANDIDATES"
 
-  # revset は commit ID に解決してから組み立てる（理由は下の項目）
-  BASE_REV="$(jj log -r "$BASE_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
-  HEAD_REV="$(jj log -r "$HEAD_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
+  # ref 名を検証し、origin 上のブックマークを commit ID へ解決する。
+  # BASE_REF / HEAD_REF に同じ規則を適用する（理由は下の 3 項目）
+  resolve_remote_rev() {
+    case "$1" in
+      '' | *[!A-Za-z0-9._/-]*)
+        printf 'ref 名に想定外の文字が含まれる: %s\n' "$1" >&2; return 1 ;;
+    esac
+    rev="$(jj log -r "remote_bookmarks(exact:\"$1\", exact:\"origin\")" \
+      --no-graph -T 'commit_id ++ "\n"')"
+    if [ "$(printf '%s\n' "$rev" | grep -c .)" -ne 1 ]; then
+      printf 'origin 上で commit ID 1 件に解決できない: %s\n' "$1" >&2; return 1
+    fi
+    printf '%s\n' "$rev"
+  }
+
+  BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1
+  HEAD_REV="$(resolve_remote_rev "$HEAD_REF")" || exit 1
   ```
 
 - **ブックマーク名を jj の revset へ直接連結しない。** `&` と `|` は git の ref 名には使えるが jj では revset の演算子で、`"$BASE_REF@origin..$HEAD_REF@origin"` のような連結は `Error: Revision ... doesn't exist` で落ちる。`jj bookmark create` 自身がこの種の名前を拒否するため発生源は Git 側で作られた／fetch されたブランチに限られるが、上のように **`BASE_REV` / `HEAD_REV`（commit ID）へ一度解決し、以降の revset は commit ID だけで組み立てる**。`gh` に渡すのは GitHub 上のブランチ名なので `$BASE_REF` / `$HEAD_REF` のままでよい。
-- **`HEAD_REF` が `^[A-Za-z0-9._/-]+$` に一致しない場合は自動で進めない。** `local_bookmarks.map(|b| b.name())` は要引用の名前を revset 用の引用付き（`"feature/x&dev"`、内部の `"` は `\"`）で返す。この表記は revset では正しいが `gh --head` やファイル名 slug には使えないため、一致しない値が返ったらユーザーに正しいブランチ名を確認する。
+- **`<名前>@origin` 形式ではなく `remote_bookmarks(exact:"<名前>", exact:"origin")` で解決する。** 裸のシンボルは revset の構文解析にかかるため、末尾が `-` の名前は `-`（親）演算子と誤読され `Failed to parse revset: Syntax error` になる（jj 0.44.0 で確認。`dev-@origin` が失敗する一方、名前の途中の `-` は `feature/jj-workflow-docs@origin` のように問題なく解決する）。`exact:` は文字列リテラルなので、この解析差に依存しない。
+- **`remote_bookmarks()` は該当が無くてもエラーにならない。** `<名前>@origin` が `Error: Revision ... doesn't exist` で落ちるのに対し、`remote_bookmarks(exact:...)` は終了コード 0 のまま空を返す。切り替えるなら **解決結果が commit ID ちょうど 1 行であることの検証が必須**（上の `resolve_remote_rev`）。省くと、未 push のブックマークが空の `BASE_REV` / `HEAD_REV` として無言で通過する。
+- **`BASE_REF` / `HEAD_REF` が `^[A-Za-z0-9._/-]+$` に一致しない場合は自動で進めない。** `local_bookmarks.map(|b| b.name())` は要引用の名前を revset 用の引用付き（`"feature/x&dev"`、内部の `"` は `\"`）で返す。この表記は revset では正しいが `gh --head` やファイル名 slug には使えず、`exact:"…"` の文字列リテラルへ埋め込むと引用が壊れる。`gh repo view` 由来の `BASE_REF` にも同じ検査を適用し（`resolve_remote_rev` の `case` がこれを担う）、一致しない値が返ったらユーザーに正しいブランチ名を確認する。
 
 ## 手順
 
@@ -107,8 +123,8 @@ description: Create a GitHub pull request for TrainLCD StationAPI that conforms 
 
      ```bash
      jj git fetch
-     BASE_REV="$(jj log -r "$BASE_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
-     HEAD_REV="$(jj log -r "$HEAD_REF@origin" --no-graph -T 'commit_id ++ "\n"')"
+     BASE_REV="$(resolve_remote_rev "$BASE_REF")" || exit 1   # 前提条件で定義したヘルパ
+     HEAD_REV="$(resolve_remote_rev "$HEAD_REF")" || exit 1
 
      jj log -r "$BASE_REV..$HEAD_REV" --no-graph \
        -T 'commit_id.short() ++ " " ++ description.first_line() ++ "\n"'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ The Worker is the workspace root package. `stationapi`, `preprocessor`, and `dat
 ## Version Control (Jujutsu)
 This repository is a **colocated jj/git checkout** — `.jj/` and `.git/` sit side by side. Agents run every version-control operation through `jj`. Do not run a `git` command that writes (`commit`, `switch`, `branch`, `push`, `rebase`, `stash`): jj re-imports the Git refs on its next invocation, so a Git-side change is either abandoned or resurfaces as a divergent change. `gh` remains the tool for pull requests, and GitHub Actions keeps consuming the Git side unchanged.
 
-- **`trunk()` resolves to `dev@origin`,** aliased in `.jj/repo/config.toml`. Prefer it to a hard-coded branch name.
+- **`trunk()` resolves to `dev@origin`,** a per-repository revset alias. Prefer it to a hard-coded branch name. jj 0.38.0 and later keep repository config outside the repository, so `.jj/repo/config.toml` is not the file to edit — run `jj config path --repo` to locate it, `jj config list 'revset-aliases."trunk()"'` to check it, and `jj config set --repo 'revset-aliases."trunk()"' dev@origin` to (re-)create it on a fresh clone.
 - **There is no staging area and no untracked file.** The working copy is itself a commit, and jj snapshots every file under the root on each command (`snapshot.auto-track = "all()"`), so a scratch file lands in the change unless `.gitignore` covers it. Nothing corresponds to `git add`, so read `jj status` before describing a change and remove what does not belong — `jj restore <path>` to drop it, `jj split` to move it into a commit of its own.
 - **Bookmarks are jj's branches, and they do not follow new commits.** After committing, move the bookmark yourself (`jj bookmark set <name> -r @-`); forgetting it makes the next push a no-op.
 - **Never rewrite a pushed commit without asking.** `jj describe`, `jj squash`, and `jj rebase` rewrite history in place, and the next `jj git push` moves the remote bookmark with force-with-lease semantics. Confirm with the user first, exactly as for a Git force push.
@@ -103,7 +103,7 @@ Equivalents for the operations this guide and `.claude/skills/create-pr` rely on
 | Repository root | `jj root` |
 | Working-copy state | `jj status` |
 | History | `jj log` (`jj log -r 'trunk()..@'` for the current change set) |
-| Bookmark closest to `@` | `jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'` |
+| Bookmark closest to `@` | `jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'` — may print more than one name (several bookmarks on one commit, or several heads above `@`). Count the lines first; on more than one, present the candidates and ask which to use instead of taking the first. |
 | Commit subjects on a bookmark | `jj log -r 'dev@origin..<bookmark>@origin' --no-graph -T 'description.first_line() ++ "\n"'` |
 | Files changed against a base | `jj diff --name-only --from 'dev@origin' --to '<bookmark>@origin'` |
 | Rebase onto the latest `dev` | `jj git fetch && jj rebase -d 'trunk()'` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,8 +76,42 @@ The Worker is the workspace root package. `stationapi`, `preprocessor`, and `dat
 - **Connected routes** – `GetConnectedRoutes` performs a bounded breadth-first search across train-type line groups. Transfers join at a shared station group, route order and per-stop pass metadata are preserved, and each returned candidate receives a deterministic virtual line-group ID in the upper half of the `uint32` range. Revisiting station groups and already-used train types is rejected to prevent cycles. Exploration loads only line-group ID, station-station-type ID, station-group ID, and pass metadata; full station rows are fetched after the result set is fixed. The search is additionally capped at eight train types, 4,096 expanded states, 65,536 evaluated candidates, and 32 results to bound computation and result size.
 - Changes to the published contract require coordinated updates to `schema/public.graphql`, the async-graphql types in `src/graphql/`, and, when the shape of a value changes, `stationapi/src/model.rs` and the DTO conversions.
 
+## Version Control (Jujutsu)
+This repository is a **colocated jj/git checkout** — `.jj/` and `.git/` sit side by side. Agents run every version-control operation through `jj`. Do not run a `git` command that writes (`commit`, `switch`, `branch`, `push`, `rebase`, `stash`): jj re-imports the Git refs on its next invocation, so a Git-side change is either abandoned or resurfaces as a divergent change. `gh` remains the tool for pull requests, and GitHub Actions keeps consuming the Git side unchanged.
+
+- **`trunk()` resolves to `dev@origin`,** aliased in `.jj/repo/config.toml`. Prefer it to a hard-coded branch name.
+- **There is no staging area and no untracked file.** The working copy is itself a commit, and jj snapshots every file under the root on each command (`snapshot.auto-track = "all()"`), so a scratch file lands in the change unless `.gitignore` covers it. Nothing corresponds to `git add`, so read `jj status` before describing a change and remove what does not belong — `jj restore <path>` to drop it, `jj split` to move it into a commit of its own.
+- **Bookmarks are jj's branches, and they do not follow new commits.** After committing, move the bookmark yourself (`jj bookmark set <name> -r @-`); forgetting it makes the next push a no-op.
+- **Never rewrite a pushed commit without asking.** `jj describe`, `jj squash`, and `jj rebase` rewrite history in place, and the next `jj git push` moves the remote bookmark with force-with-lease semantics. Confirm with the user first, exactly as for a Git force push.
+- **`jj undo` reverses the last operation** and `jj op log` lists them; prefer both to reconstructing state by hand.
+
+A typical change:
+```bash
+jj git fetch                        # refresh dev@origin and the other remote bookmarks
+jj new 'trunk()'                    # start a new change on top of dev@origin
+# ... edit files; jj snapshots them automatically ...
+jj status                           # confirm exactly what the change contains
+jj commit -m "日本語の単文"          # describe @ and open a fresh empty working copy on top
+jj bookmark create feature/<description> -r @-
+jj git push -b feature/<description>
+```
+
+Equivalents for the operations this guide and `.claude/skills/create-pr` rely on:
+
+| Purpose | Command |
+| --- | --- |
+| Repository root | `jj root` |
+| Working-copy state | `jj status` |
+| History | `jj log` (`jj log -r 'trunk()..@'` for the current change set) |
+| Bookmark closest to `@` | `jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'` |
+| Commit subjects on a bookmark | `jj log -r 'dev@origin..<bookmark>@origin' --no-graph -T 'description.first_line() ++ "\n"'` |
+| Files changed against a base | `jj diff --name-only --from 'dev@origin' --to '<bookmark>@origin'` |
+| Rebase onto the latest `dev` | `jj git fetch && jj rebase -d 'trunk()'` |
+
+`CONTRIBUTING.md` still documents the Git workflow, because outside contributors are not required to install jj. Keep the two aligned in intent — base branch, naming convention, and pull-request rules are identical; only the commands differ.
+
 ## Contribution Guidelines
-- **Git-flow** – Follow Git-flow with `dev` serving as this repository's `develop` branch. Create ordinary work branches from the latest `origin/dev`, use the `feature/<description>` naming convention, and target their pull requests to `dev`. Do not create or target a branch named `develop`.
+- **Git-flow** – Follow Git-flow with `dev` serving as this repository's `develop` branch. Create ordinary work bookmarks from the latest `trunk()` (`dev@origin`) with `jj new 'trunk()'`, use the `feature/<description>` naming convention, and target their pull requests to `dev`. Do not create or target a bookmark named `develop`. **Version Control (Jujutsu)** above has the full command sequence.
 - **Pull requests** – Assign every pull request to `@TinyKitten` when creating it, open it as ready for review rather than as a draft, and use `.github/pull_request_template.md` without omitting or replacing its sections or checklists.
 - **Prioritize quality and performance over implementation speed** – Always favor code quality and runtime performance over velocity. Be mindful of algorithmic complexity and look for opportunities to replace O(n×m) linear scans with O(n+m) indexed lookups (e.g., HashMaps). The indexes are rebuilt on every isolate start and every request scans them, so prefer indexed lookups over repeated full scans. When a change affects performance, document the before/after complexity and query plan impact in the pull request.
 - Document the commands you executed (for example, ``make fmt && make clippy && make test``) and their outcomes in every pull request.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,7 +103,7 @@ Equivalents for the operations this guide and `.claude/skills/create-pr` rely on
 | Repository root | `jj root` |
 | Working-copy state | `jj status` |
 | History | `jj log` (`jj log -r 'trunk()..@'` for the current change set) |
-| Bookmark closest to `@` | `jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n")'` — may print more than one name (several bookmarks on one commit, or several heads above `@`). Count the lines first; on more than one, present the candidates and ask which to use instead of taking the first. |
+| Bookmark closest to `@` | `jj log -r 'heads(::@ & bookmarks())' --no-graph -T 'local_bookmarks.map(\|b\| b.name()).join("\n") ++ "\n"'` — the trailing `++ "\n"` is what separates one revision's output from the next; without it several heads print as one run-on line. May print more than one name (several bookmarks on one commit, or several heads above `@`). Count the lines first; on more than one, present the candidates and ask which to use instead of taking the first. |
 | Commit subjects on a bookmark | `jj log -r 'dev@origin..<bookmark>@origin' --no-graph -T 'description.first_line() ++ "\n"'` |
 | Files changed against a base | `jj diff --name-only --from 'dev@origin' --to '<bookmark>@origin'` |
 | Rebase onto the latest `dev` | `jj git fetch && jj rebase -d 'trunk()'` |


### PR DESCRIPTION
## 概要

<!-- このPRで何を変更したかを簡潔に記述してください -->

## 変更の種類

<!-- 該当するものにチェックを入れてください -->

- [ ] バグ修正
- [ ] 新機能
- [ ] データの修正・追加
- [ ] リファクタリング
- [x] ドキュメント
- [ ] CI/CD
- [ ] その他

## 変更内容

- `AGENTS.md` に **Version Control (Jujutsu)** 節を新設し、colocated な jj/git チェックアウトでの運用を明文化した。書き込み系 git コマンドを避ける理由（jj が次回起動時に Git ref を再取り込みし、変更が破棄されるか divergent change になる）、`trunk()` が `dev@origin` を指すこと、ステージング領域と未追跡ファイルという概念が無いこと、ブックマークは自動追従しないこと、push 済みコミットを無断で書き換えないこと、`jj undo` / `jj op log` での巻き戻しを記載。
- 同節に典型的な変更フローのコマンド列と、`jj root` / `jj status` / `jj log` / ブックマーク解決 / 差分取得など従来 git で書いていた操作の対応表を追加。
- **Contribution Guidelines** の Git-flow 項を、`jj new 'trunk()'` で作業ブックマークを切る手順に更新。`CONTRIBUTING.md` は外部コントリビューター向けに git 手順のまま据え置く旨を併記した（base ブランチ・命名規則・PR ルールは同一で、コマンドのみ異なる）。
- `.claude/skills/create-pr` を jj ベースへ全面的に書き換え。head 推論を `heads(::@ & bookmarks())` に、差分取得を `<base>@origin..<head>@origin` revset に、ブランチ切り出しを `jj commit` + `jj bookmark create` + `jj git push` に置き換え、注意事項も force push ではなく履歴書き換え（`jj describe` / `jj squash` / `jj rebase`）を対象とする表現に改めた。

## テスト

<!-- どのようにテストしたかを記述してください -->

- [ ] `make fmt` が通ること
- [ ] `make clippy` が通ること（wasm32 ターゲットを含む）
- [ ] `make test` が通ること

省略: ドキュメントのみの変更で、コード本体（`stationapi/src/**` ほか）およびデータに差分が無いため `cargo` チェックは実行していない。

本文中のコマンドは jj 0.44.0 で確認した。`jj git push` の `--allow-new` は現行バージョンでは廃止されており、`-b` 指定で未トラックのブックマークが自動的にトラックされるため、当該フラグを含めずに記載している。

## 関連Issue

<!-- 関連するIssueがあればリンクしてください。例: Closes #123 -->

## スクリーンショット（任意）

<!-- UIやレスポンスに関する変更の場合、スクリーンショットを添付してください -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **ドキュメント**
  - PR作成手順を、Git中心からJujutsu（jj）中心の運用に更新しました。
  - jjでのブックマーク、履歴確認、差分取得、コミット分割、pushの手順を整理しました。
  - PRのbase/headとリモート上のコミットを安全かつ正確に確認する手順を追加しました。
  - 最新情報の取得後に差分を確認し、未push・未解決の状態や不完全な差分を検出した場合は、PR検索・作成を中断するよう改善しました。
  - ブックマーク一覧で複数リビジョンが正しく改行表示されるよう説明を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->